### PR TITLE
Status line

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ I embarked on this project to deepen my understanding of the groundbreaking pape
   - Command-line parameters have been added to specify the training data path and the output path. Note that the output path will not be automatically overwritten anymore.
   - CUDA version restrictions have been relaxed a bit to 11.7 or higher. The CUDA architecture of the system on which the software is being compiled is now auto-detected automatically.
   - Experimental feature to monitor the average convergence rate throughout training has been added (see the command-line options section for more details).
+  - Added updating status line, instead of printing many lines of output during a run
   - There are a lot good first issues to grab if you would like to contribute.
   
 If you encounter any problems or issues, please [open an issue](https://github.com/MrNeRF/gaussian-splatting-cuda/issues) on GitHub.

--- a/src/gaussian.cu
+++ b/src/gaussian.cu
@@ -158,11 +158,9 @@ void prune_optimizer(torch::optim::Adam* optimizer, const torch::Tensor& mask, t
 }
 
 void GaussianModel::prune_points(torch::Tensor mask) {    
-    //std::cout << "Before pruning " << mask.sizes()[0] << " points" << std::endl;
     // reverse to keep points
     auto valid_point_mask = ~mask;
     int true_count = valid_point_mask.sum().item<int>();
-    //std::cout << "Pruning left " << true_count << " points" << std::endl;
     auto indices = torch::nonzero(valid_point_mask == true).index({torch::indexing::Slice(torch::indexing::None, torch::indexing::None), torch::indexing::Slice(torch::indexing::None, 1)}).squeeze(-1);
     prune_optimizer(_optimizer.get(), indices, _xyz, 0);
     prune_optimizer(_optimizer.get(), indices, _features_dc, 1);

--- a/src/gaussian.cu
+++ b/src/gaussian.cu
@@ -157,11 +157,12 @@ void prune_optimizer(torch::optim::Adam* optimizer, const torch::Tensor& mask, t
     optimizer->state()[c10::guts::to_string(optimizer->param_groups()[param_position].params()[0].unsafeGetTensorImpl())] = std::move(adamParamStates);
 }
 
-void GaussianModel::prune_points(torch::Tensor mask) {
+void GaussianModel::prune_points(torch::Tensor mask) {    
+    //std::cout << "Before pruning " << mask.sizes()[0] << " points" << std::endl;
     // reverse to keep points
     auto valid_point_mask = ~mask;
     int true_count = valid_point_mask.sum().item<int>();
-    //std::cout << "Pruning " << true_count << " points" << std::endl;
+    //std::cout << "Pruning left " << true_count << " points" << std::endl;
     auto indices = torch::nonzero(valid_point_mask == true).index({torch::indexing::Slice(torch::indexing::None, torch::indexing::None), torch::indexing::Slice(torch::indexing::None, 1)}).squeeze(-1);
     prune_optimizer(_optimizer.get(), indices, _xyz, 0);
     prune_optimizer(_optimizer.get(), indices, _features_dc, 1);

--- a/src/main.cu
+++ b/src/main.cu
@@ -174,14 +174,14 @@ int main(int argc, char* argv[]) {
             // XXX Use thousand separators, but doesn't work for some reason
             status_line.imbue(std::locale(""));
             status_line
-                << "\rIteration: " << std::setw(5) << iter
+                << "\rIter: " << std::setw(5) << iter
                 << "  Loss: " << std::fixed << std::setw(9) << std::setprecision(6) << loss.item<float>();
             if (optimParams.early_stopping) {
                 status_line 
-                    << "  Avg convergence rate: " << std::fixed << std::setw(9) << std::setprecision(6) << avg_converging_rate;
+                    << "  ACR: " << std::fixed << std::setw(9) << std::setprecision(6) << avg_converging_rate;
             }
             status_line
-                << "  Gaussian splats: " << std::setw(8) << (int)gaussians.Get_xyz().size(0)
+                << "  Splats: " << std::setw(8) << (int)gaussians.Get_xyz().size(0)
                 << "  Time: " << std::fixed << std::setw(8) << std::setprecision(3) << time_elapsed.count() << "s"
                 << "  Avg iter/s: " << std::fixed << std::setw(5) << std::setprecision(1) << 1.0*iter/time_elapsed.count()
                 << "  " // Some extra whitespace, in case a "Pruning ... points" message gets printed after

--- a/src/main.cu
+++ b/src/main.cu
@@ -174,14 +174,14 @@ int main(int argc, char* argv[]) {
             // XXX Use thousand separators, but doesn't work for some reason
             status_line.imbue(std::locale(""));
             status_line
-                << "\rIter: " << std::setw(5) << iter
+                << "\rIter: " << std::setw(6) << iter
                 << "  Loss: " << std::fixed << std::setw(9) << std::setprecision(6) << loss.item<float>();
             if (optimParams.early_stopping) {
                 status_line 
                     << "  ACR: " << std::fixed << std::setw(9) << std::setprecision(6) << avg_converging_rate;
             }
             status_line
-                << "  Splats: " << std::setw(8) << (int)gaussians.Get_xyz().size(0)
+                << "  Splats: " << std::setw(10) << (int)gaussians.Get_xyz().size(0)
                 << "  Time: " << std::fixed << std::setw(8) << std::setprecision(3) << time_elapsed.count() << "s"
                 << "  Avg iter/s: " << std::fixed << std::setw(5) << std::setprecision(1) << 1.0*iter/time_elapsed.count()
                 << "  " // Some extra whitespace, in case a "Pruning ... points" message gets printed after

--- a/src/main.cu
+++ b/src/main.cu
@@ -222,12 +222,11 @@ int main(int argc, char* argv[]) {
                 gaussians.Add_densification_stats(viewspace_point_tensor, visibility_filter);
                 if (iter > optimParams.densify_from_iter && iter % optimParams.densification_interval == 0) {
                     // @TODO: Not sure about type
-                    float size_threshold = iter > optimParams.opacity_reset_interval ? 20.f : -1.f;                    
+                    float size_threshold = iter > optimParams.opacity_reset_interval ? 20.f : -1.f;
                     gaussians.Densify_and_prune(optimParams.densify_grad_threshold, 0.005f, scene.Get_cameras_extent(), size_threshold);
                 }
 
                 if (iter % optimParams.opacity_reset_interval == 0 || (modelParams.white_background && iter == optimParams.densify_from_iter)) {
-                    //std::cout << "iteration " << iter << " resetting opacity" << std::endl;
                     gaussians.Reset_opacity();
                 }
             }


### PR DESCRIPTION
Okay, seems I mistimed trying to add a status line with your addition of the convergence threshold :)

This adds a status line that is continuously refreshed with basic stats, including avg iterations/s and overall time. I commented out the periodic pruning and opacity-clearing messages as they were causing the status line to get newlined and start over.

If you don't want to use this then don't.

PS I need to start using feature branches on my end...