### PR TITLE
include cstdint in rasterizer_impl.h

### DIFF
--- a/cuda_rasterizer/rasterizer_impl.h
+++ b/cuda_rasterizer/rasterizer_impl.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "rasterizer.h"
+#include <cstdint>
 #include <cuda_runtime_api.h>
 #include <iostream>
 #include <vector>


### PR DESCRIPTION
I needed to include `<cstdint>` to avoid
```
/home/miriam/gaussian-splatting-cuda/cuda_rasterizer/rasterizer_impl.h(22): error: namespace "std" has no member "uintptr_t"
          std::size_t offset = (reinterpret_cast<std::uintptr_t>(chunk) + alignment - 1) & ~(alignment - 1);
                                                      ^

/home/miriam/gaussian-splatting-cuda/cuda_rasterizer/rasterizer_impl.h(37): error: identifier "uint32_t" is undefined
          uint32_t* point_offsets;
          ^

/home/miriam/gaussian-splatting-cuda/cuda_rasterizer/rasterizer_impl.h(38): error: identifier "uint32_t" is undefined
          uint32_t* tiles_touched;
          ^

/home/miriam/gaussian-splatting-cuda/cuda_rasterizer/rasterizer_impl.h(45): error: identifier "uint32_t" is undefined
          uint32_t* n_contrib;
          ^

/home/miriam/gaussian-splatting-cuda/cuda_rasterizer/rasterizer_impl.h(53): error: identifier "uint64_t" is undefined
          uint64_t* point_list_keys_unsorted;
          ^

/home/miriam/gaussian-splatting-cuda/cuda_rasterizer/rasterizer_impl.h(54): error: identifier "uint64_t" is undefined
          uint64_t* point_list_keys;
          ^

/home/miriam/gaussian-splatting-cuda/cuda_rasterizer/rasterizer_impl.h(55): error: identifier "uint32_t" is undefined
          uint32_t* point_list_unsorted;
          ^

/home/miriam/gaussian-splatting-cuda/cuda_rasterizer/rasterizer_impl.h(56): error: identifier "uint32_t" is undefined
          uint32_t* point_list;
          ^
```