### PR TITLE
read quaternions correctly and use toRotationMatrix()

### DIFF
--- a/src/camera_utils.cu
+++ b/src/camera_utils.cu
@@ -79,20 +79,7 @@ float focal2fov(float focal, int pixels) {
 }
 
 Eigen::Matrix3f qvec2rotmat(const Eigen::Quaternionf& q) {
-    Eigen::Vector4f qvec = q.coeffs(); // [x, y, z, w]
-
-    Eigen::Matrix3f rotmat;
-    rotmat << 1.f - 2.f * qvec[2] * qvec[2] - 2.f * qvec[3] * qvec[3],
-        2.f * qvec[1] * qvec[2] - 2.f * qvec[0] * qvec[3],
-        2.f * qvec[3] * qvec[1] + 2.f * qvec[0] * qvec[2],
-        2.f * qvec[1] * qvec[2] + 2.f * qvec[0] * qvec[3],
-        1.f - 2.f * qvec[1] * qvec[1] - 2.f * qvec[3] * qvec[3],
-        2.f * qvec[2] * qvec[3] - 2.f * qvec[0] * qvec[1],
-        2.f * qvec[3] * qvec[1] - 2.f * qvec[0] * qvec[2],
-        2.f * qvec[2] * qvec[3] + 2.f * qvec[0] * qvec[1],
-        1.f - 2.f * qvec[1] * qvec[1] - 2.f * qvec[2] * qvec[2];
-
-    return rotmat;
+    return q.toRotationMatrix();
 }
 
 Eigen::Quaternionf rotmat2qvec(const Eigen::Matrix3f& R) {

--- a/src/read_utils.cu
+++ b/src/read_utils.cu
@@ -226,10 +226,10 @@ std::vector<Image> read_images_binary(std::filesystem::path file_path) {
     for (size_t i = 0; i < image_count; ++i) {
         const auto image_ID = read_binary_value<uint32_t>(*image_stream_buffer);
         auto& img = images.emplace_back(image_ID);
+        img._qvec.w() = static_cast<float>(read_binary_value<double>(*image_stream_buffer));
         img._qvec.x() = static_cast<float>(read_binary_value<double>(*image_stream_buffer));
         img._qvec.y() = static_cast<float>(read_binary_value<double>(*image_stream_buffer));
         img._qvec.z() = static_cast<float>(read_binary_value<double>(*image_stream_buffer));
-        img._qvec.w() = static_cast<float>(read_binary_value<double>(*image_stream_buffer));
         img._qvec.normalize();
 
         img._tvec.x() = static_cast<float>(read_binary_value<double>(*image_stream_buffer));


### PR DESCRIPTION
colmap actually stores the quaternions in `w,x,y,z` instead of `x,y,z,w`, if we read it correctly we can just call `toRotationMatrix()` instead of needing to manually do the conversion ourselves to accidentally getting it right