### PR TITLE
remove transpose() on camera_info->_R that causes confusion for reading

### DIFF
--- a/src/camera_utils.cu
+++ b/src/camera_utils.cu
@@ -10,7 +10,7 @@
 torch::Tensor getWorld2View2(const Eigen::Matrix3f& R, const Eigen::Vector3f& t,
                              const Eigen::Vector3f& translate /*= Eigen::Vector3d::Zero()*/, float scale /*= 1.0*/) {
     Eigen::Matrix4f Rt = Eigen::Matrix4f::Zero();
-    Rt.block<3, 3>(0, 0) = R.transpose();
+    Rt.block<3, 3>(0, 0) = R;
     Rt.block<3, 1>(0, 3) = t;
     Rt(3, 3) = 1.0;
 
@@ -30,7 +30,7 @@ torch::Tensor getWorld2View2(const Eigen::Matrix3f& R, const Eigen::Vector3f& t,
 Eigen::Matrix4f getWorld2View2Eigen(const Eigen::Matrix3f& R, const Eigen::Vector3f& t,
                                     const Eigen::Vector3f& translate /*= Eigen::Vector3d::Zero()*/, float scale /*= 1.0*/) {
     Eigen::Matrix4f Rt = Eigen::Matrix4f::Zero();
-    Rt.block<3, 3>(0, 0) = R.transpose();
+    Rt.block<3, 3>(0, 0) = R;
     Rt.block<3, 1>(0, 3) = t;
     Rt(3, 3) = 1.0;
 

--- a/src/read_utils.cu
+++ b/src/read_utils.cu
@@ -349,7 +349,7 @@ std::vector<CameraInfo> read_colmap_cameras(const std::filesystem::path file_pat
                 camera_info->_channels = channels;
                 camera_info->_img_data = img_data;
 
-                camera_info->_R = qvec2rotmat(image->_qvec).transpose();
+                camera_info->_R = qvec2rotmat(image->_qvec);
                 camera_info->_T = image->_tvec;
 
                 camera_info->_image_name = image->_name;


### PR DESCRIPTION
Couldn't figure out why the `transpose()` was there at the first place, in my opinion this causes confusion and should be removed. After fixing up `getWorld2View2` and `getWorld2View2Eigen` I can confirm that the truck dataset works like usual.