### PR TITLE
remove unnecessary std::reverse

### DIFF
--- a/src/main.cu
+++ b/src/main.cu
@@ -42,7 +42,6 @@ std::vector<int> get_random_indices(int max_index) {
     std::iota(indices.begin(), indices.end(), 0);
     // Shuffle the vector
     std::shuffle(indices.begin(), indices.end(), std::default_random_engine());
-    std::reverse(indices.begin(), indices.end());
     return indices;
 }
 


### PR DESCRIPTION
`std::reverse` in `get_random_indices` looks like unnecessary computation to me, so proposing to remove it, also truck dataset still works like usual after this change