### PR TITLE
use torch::abs instead of torch::linalg::vector_norm for better readability since grads is [N, 1]

### DIFF
--- a/src/gaussian.cu
+++ b/src/gaussian.cu
@@ -229,7 +229,7 @@ void GaussianModel::densify_and_split(torch::Tensor& grads, float grad_threshold
 
 void GaussianModel::densify_and_clone(torch::Tensor& grads, float grad_threshold, float scene_extent) {
     // Extract points that satisfy the gradient condition
-    torch::Tensor selected_pts_mask = torch::where(torch::linalg::vector_norm(grads, {2}, 1, true, torch::kFloat32) >= grad_threshold,
+    torch::Tensor selected_pts_mask = torch::where(torch::abs(grads) >= grad_threshold,
                                                    torch::ones_like(grads.index({torch::indexing::Slice()})).to(torch::kBool),
                                                    torch::zeros_like(grads.index({torch::indexing::Slice()})).to(torch::kBool))
                                           .to(torch::kLong);


### PR DESCRIPTION
Probably will save people a few mins who read the code in the future. At least initially I got confused for a little bit on why L2 norm is called.