### PR TITLE
remove unnecessary .squeeze when calculating prune_filter

### DIFF
--- a/src/gaussian.cu
+++ b/src/gaussian.cu
@@ -224,8 +224,7 @@ void GaussianModel::densify_and_split(torch::Tensor& grads, float grad_threshold
 
     densification_postfix(new_xyz, new_features_dc, new_features_rest, new_scaling, new_rotation, new_opacity);
 
-    torch::Tensor prune_filter = torch::cat({selected_pts_mask.squeeze(-1), torch::zeros({N * selected_pts_mask.sum().item<int>()}).to(torch::kBool).to(torch::kCUDA)});
-    // torch::Tensor prune_filter = torch::cat({selected_pts_mask.squeeze(-1), torch::zeros({N * selected_pts_mask.sum().item<int>()})}).to(torch::kBool).to(torch::kCUDA);
+    torch::Tensor prune_filter = torch::cat({selected_pts_mask, torch::zeros({N * selected_pts_mask.sum().item<int>()}).to(torch::kBool).to(torch::kCUDA)});
     prune_filter = torch::logical_or(prune_filter, (Get_opacity() < min_opacity).squeeze(-1));
     prune_points(prune_filter);
 }


### PR DESCRIPTION
selected_pts_mask is [N], so the .squeeze(-1) here should be redundant