### PR TITLE
fix fatal error: glm/glm.hpp: No such file or directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ target_link_libraries(gaussian_kernels
         CUDA::curand
         CUDA::cublas
         ${TORCH_LIBRARIES}  # This provides c10/cuda/CUDAGuard.h
+        glm
         # simple-knn  # Commented out - not available
 )
 


### PR DESCRIPTION
Fixes
```
/home/miriam/gaussian-splatting-cuda/include/kernels/backward.h:19:10: fatal error: glm/glm.hpp: No such file or directory
   19 | #include <glm/glm.hpp>
      |          ^~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/gaussian_kernels.dir/build.make:125: CMakeFiles/gaussian_kernels.dir/kernels/cuda_rasterizer/backward.cu.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from /home/miriam/gaussian-splatting-cuda/kernels/cuda_rasterizer/forward.cu:13:
/home/miriam/gaussian-splatting-cuda/include/kernels/forward.h:19:10: fatal error: glm/glm.hpp: No such file or directory
   19 | #include <glm/glm.hpp>
      |          ^~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/gaussian_kernels.dir/build.make:110: CMakeFiles/gaussian_kernels.dir/kernels/cuda_rasterizer/forward.cu.o] Error 1
/home/miriam/gaussian-splatting-cuda/kernels/cuda_rasterizer/rasterizer_impl.cu:23:10: fatal error: glm/glm.hpp: No such file or directory
   23 | #include <glm/glm.hpp>
      |          ^~~~~~~~~~~~~
compilation terminated.
```