### PR TITLE
fix compilation error due to glm

### DIFF
--- a/gsplat/CMakeLists.txt
+++ b/gsplat/CMakeLists.txt
@@ -65,6 +65,7 @@ target_link_libraries(gsplat_backend
         CUDA::cudart
         CUDA::curand
         CUDA::cublas
+        glm
 )
 
 # Compile options for both CUDA and C++


### PR DESCRIPTION
Seeing the below without this PR
```
/home/miriam/gaussian-splatting-cuda/gsplat/Common.h:5:10: fatal error: glm/gtc/type_ptr.hpp: No such file or directory
    5 | #include <glm/gtc/type_ptr.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```