### PR TITLE
Feature/windows compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,6 @@ target_link_libraries(gaussian_host
         glfw
         glad
         imgui
-        dl
         Threads::Threads
         args
         Python3::Python
@@ -115,24 +114,48 @@ target_link_libraries(gaussian_host
         ${OPENGL_LIBRARIES}
         CUDA::cudart    # Add CUDA runtime for interop
 )
+if(UNIX)
+    target_link_libraries(gaussian_host PUBLIC dl)
+endif()
 
-# Fast C++ compilation with proper debug symbols
-target_compile_options(gaussian_host PRIVATE
-        $<$<CONFIG:Debug>:-O0 -g -fno-omit-frame-pointer -DDEBUG>
-        $<$<CONFIG:Release>:-O3 -DNDEBUG -march=native>
-)
+# Compilation flags
+if(MSVC)
+    target_compile_options(gaussian_host PRIVATE
+            $<$<CONFIG:Debug>:/Od /Zi /DDEBUG /EHsc>
+            $<$<CONFIG:Release>:/O2 /DNDEBUG /EHsc>
+    )
+    # Add definitions for Windows specific macros, e.g. suppress warnings
+    target_compile_definitions(gaussian_host PRIVATE _CRT_SECURE_NO_WARNINGS)
+else()
+    # Fast C++ compilation with proper debug symbols for GCC/Clang
+    target_compile_options(gaussian_host PRIVATE
+            $<$<CONFIG:Debug>:-O0 -g -fno-omit-frame-pointer -DDEBUG>
+            $<$<CONFIG:Release>:-O3 -DNDEBUG -march=native>
+    )
+endif()
 
 # Ensure debug symbols in debug builds
 set_target_properties(gaussian_host PROPERTIES
         DEBUG_POSTFIX d
 )
 
-add_definitions(-DPROJECT_ROOT_PATH="${PROJ_ROOT_DIR}")
+add_definitions(-DPROJECT_ROOT_PATH="${PROJ_ROOT_DIR}") # This is generally okay
 
+# Global flags (less preferred than target_compile_options but sometimes used)
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0")
-    set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -g -G -O0")
+    if(MSVC)
+        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd /Zi /Ob0 /Od /RTC1")
+        set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -G -O0") # Keep -G for CUDA debug
+    else()
+        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0")
+        set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -g -G -O0")
+    endif()
+elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
+    if(MSVC)
+        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD /O2 /Ob2 /DNDEBUG")
+    endif()
 endif()
+
 
 # =============================================================================
 # KERNEL LIBRARY - Keep minimal for backwards compatibility
@@ -153,7 +176,7 @@ endif()
 add_library(gaussian_kernels STATIC ${KERNEL_SOURCES})
 
 set_target_properties(gaussian_kernels PROPERTIES
-        CUDA_ARCHITECTURES native
+        CUDA_ARCHITECTURES native # Should be fine, can be specified e.g. 75;80;86;89;90 if needed
         CUDA_SEPARABLE_COMPILATION ON
         POSITION_INDEPENDENT_CODE ON
         CUDA_RESOLVE_DEVICE_SYMBOLS ON
@@ -186,10 +209,18 @@ if(CUDA_GL_INTEROP_FOUND)
     # target_compile_definitions(gaussian_kernels PUBLIC CUDA_GL_INTEROP_ENABLED)
 endif()
 
-target_compile_options(gaussian_kernels PRIVATE
-        $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CUDA>>:-O0 -g -G -lineinfo>
-        $<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:CUDA>>:-O3 -use_fast_math --ptxas-options=-v>
-)
+# CUDA Compilation flags
+if(MSVC)
+    target_compile_options(gaussian_kernels PRIVATE
+        $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CUDA>>:-G -lineinfo -O0> # Basic debug for CUDA on MSVC
+        $<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:CUDA>>:-O3 -use_fast_math --ptxas-options=-v> # Keep release flags
+    )
+else()
+    target_compile_options(gaussian_kernels PRIVATE
+            $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CUDA>>:-O0 -g -G -lineinfo>
+            $<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:CUDA>>:-O3 -use_fast_math --ptxas-options=-v>
+    )
+endif()
 
 # =============================================================================
 # VISUALIZER LIBRARY (separate for OpenGL/CUDA interop code)
@@ -232,7 +263,7 @@ endif()
 add_executable(${PROJECT_NAME} src/main.cpp)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
-        CUDA_ARCHITECTURES native
+        CUDA_ARCHITECTURES native # Should be fine
         CUDA_SEPARABLE_COMPILATION ON
         CUDA_RESOLVE_DEVICE_SYMBOLS ON
 )
@@ -265,8 +296,8 @@ target_link_libraries(${PROJECT_NAME} PRIVATE ${MAIN_LINK_LIBRARIES})
 
 # Platform-specific settings
 if(WIN32)
+    # Copy Torch DLLs
     file(GLOB TORCH_DLLS "${Torch_DIR}/../../../lib/*.dll")
-
     foreach(TORCH_DLL ${TORCH_DLLS})
         add_custom_command(
                 TARGET ${PROJECT_NAME}
@@ -275,18 +306,53 @@ if(WIN32)
                 "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
     endforeach()
 
-    # Copy OpenGL related DLLs if needed
-    if(OPENGL_LIBRARIES)
-        get_filename_component(OPENGL_LIB_DIR ${OPENGL_LIBRARIES} DIRECTORY)
-        file(GLOB OPENGL_DLLS "${OPENGL_LIB_DIR}/*.dll")
-        foreach(DLL ${OPENGL_DLLS})
+    # Copy TBB DLLs if TBB is found and linkage is dynamic (common on Windows)
+    if(TBB_FOUND AND TBB_tbb_LIBRARY_RELEASE) # Check if TBB was found and Release lib is set
+        get_filename_component(TBB_LIB_DIR "${TBB_tbb_LIBRARY_RELEASE}" DIRECTORY)
+        file(GLOB TBB_DLLS "${TBB_LIB_DIR}/tbb*.dll") # Adjust pattern as needed
+         foreach(TBB_DLL ${TBB_DLLS})
             add_custom_command(
                     TARGET ${PROJECT_NAME}
                     POST_BUILD
-                    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${DLL}"
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${TBB_DLL}"
                     "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
         endforeach()
     endif()
+    if(TBB_FOUND AND TBB_tbbmalloc_LIBRARY_RELEASE) # Check for tbbmalloc
+        get_filename_component(TBB_MALLOC_LIB_DIR "${TBB_tbbmalloc_LIBRARY_RELEASE}" DIRECTORY)
+        file(GLOB TBB_MALLOC_DLLS "${TBB_MALLOC_LIB_DIR}/tbbmalloc*.dll")
+         foreach(TBB_MALLOC_DLL ${TBB_MALLOC_DLLS})
+            add_custom_command(
+                    TARGET ${PROJECT_NAME}
+                    POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${TBB_MALLOC_DLL}"
+                    "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
+        endforeach()
+    endif()
+
+
+    # Copy OpenGL related DLLs if needed (GLFW might be one)
+    # This part seems okay, but depends on how GLFW/glad are built/found
+    if(OPENGL_LIBRARIES AND EXISTS "${OPENGL_LIBRARIES}") # Check if var is set and file exists
+       get_filename_component(OPENGL_LIB_PATH ${OPENGL_LIBRARIES} DIRECTORY)
+       # Attempt to copy DLLs from the same directory as the .lib file.
+       # This is a heuristic and might need adjustment based on how GLFW is packaged.
+       file(GLOB OPENGL_POSSIBLE_DLLS "${OPENGL_LIB_PATH}/*.dll")
+       if(OPENGL_POSSIBLE_DLLS)
+            foreach(DLL ${OPENGL_POSSIBLE_DLLS})
+                add_custom_command(
+                        TARGET ${PROJECT_NAME}
+                        POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${DLL}"
+                        "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
+            endforeach()
+       endif()
+    endif()
+    # For GLFW, if it's a shared library, its DLL also needs to be available.
+    # If glfw is built as a static lib as part of this project (e.g. via external), this isn't an issue.
+    # If it's a shared system library, its DLL needs to be in PATH or copied.
+    # The existing OPENGL_LIBRARIES check might cover GLFW if it's found as a .lib from a dir with .dlls
+
 elseif(UNIX)
     # Linux specific settings
     target_link_libraries(${PROJECT_NAME} PRIVATE GL GLU)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,12 @@ Join our growing community for discussions, support, and updates:
 6. **C++ Compiler**:
     - **Linux**: GCC or Clang with C++17 support.
     - **Windows**: Visual Studio 2022 (Desktop development with C++ workload).
-7. Other dependencies (GLFW, GLM, TBB, etc.) are handled automatically by CMake via submodules or `find_package`. For TBB on Windows, installing Intel oneAPI Base Toolkit can provide it.
+7. **Git** (for cloning and submodule management).
+8. Other dependencies (GLFW, GLM, TBB, etc.) are handled automatically by CMake.
+    - **Submodules**: External libraries like `json`, `args`, `glfw`, `glm`, `glad`, `imgui` are included as git submodules. Ensure these are initialized correctly (see build instructions).
+    - **TBB (Threading Building Blocks)**:
+        - On Linux, CMake will try to find TBB via `find_package`. Ensure it's installed (e.g., `sudo apt-get install libtbb-dev`).
+        - On Windows, TBB might need to be installed separately, for example, via the Intel oneAPI Base Toolkit. If CMake cannot find TBB, you may need to set the `TBB_DIR` CMake variable to point to your TBB installation's CMake configuration directory (e.g., `C:/Program Files (x86)/Intel/oneAPI/tbb/latest/lib/cmake/TBB`).
 
 ### Hardware Prerequisites
 1. **NVIDIA GPU** with CUDA support
@@ -87,12 +92,25 @@ Join our growing community for discussions, support, and updates:
 
 ### Build Instructions
 
+**Important First Step (All Platforms):**
+
+This project uses git submodules for some external dependencies. After cloning, or if you pulled changes that might affect submodules, ensure they are initialized and updated:
+```bash
+# If you just cloned:
+git clone https://github.com/MrNeRF/gaussian-splatting-cuda
+cd gaussian-splatting-cuda
+git submodule update --init --recursive
+
+# If you already cloned and just need to update submodules:
+# cd gaussian-splatting-cuda
+# git submodule update --recursive
+```
+
 #### For Linux
 
 ```bash
-# Clone the repository with submodules
-git clone --recursive https://github.com/MrNeRF/gaussian-splatting-cuda
-cd gaussian-splatting-cuda
+# Assumes you are in the gaussian-splatting-cuda directory
+# and submodules are initialized (see "Important First Step" above)
 
 # Download and setup LibTorch (for CUDA 11.8)
 wget https://download.pytorch.org/libtorch/cu118/libtorch-cxx11-abi-shared-with-deps-2.7.0%2Bcu118.zip
@@ -110,12 +128,8 @@ make -j$(nproc) # or cmake --build . --config Release -- -j$(nproc)
 
 #### For Windows (Visual Studio 2022)
 
-1.  **Clone the repository with submodules:**
-    ```bash
-    git clone --recursive https://github.com/MrNeRF/gaussian-splatting-cuda
-    cd gaussian-splatting-cuda
-    git submodule update --init --recursive
-    ```
+1.  **Clone the repository and initialize submodules:**
+    Follow the "Important First Step (All Platforms)" instructions above. Make sure you are in the `gaussian-splatting-cuda` directory.
 
 2.  **Download and setup LibTorch (for CUDA 11.8, Release version):**
     *   Go to the [PyTorch website](https://pytorch.org/get-started/locally/) and select the appropriate options for your setup:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ make -j$(nproc) # or cmake --build . --config Release -- -j$(nproc)
     ```bash
     git clone --recursive https://github.com/MrNeRF/gaussian-splatting-cuda
     cd gaussian-splatting-cuda
+    git submodule update --init --recursive
     ```
 
 2.  **Download and setup LibTorch (for CUDA 11.8, Release version):**

--- a/README.md
+++ b/README.md
@@ -62,41 +62,99 @@ Join our growing community for discussions, support, and updates:
 ## Build and Execution Instructions
 
 ### Software Prerequisites
-1. **Linux** (tested with Ubuntu 22.04) - Windows is currently not supported
-2. **CMake** 3.24 or higher
-3. **CUDA** 11.8 or higher (may work with lower versions with manual configuration)
-4. **Python** with development headers
-5. **LibTorch 2.7.0** - Setup instructions below
-6. Other dependencies are handled automatically by CMake
+1. **Operating System**:
+    - **Linux** (tested with Ubuntu 22.04)
+    - **Windows 10/11** (tested with Visual Studio 2022)
+2. **CMake** 3.24 or higher (add to PATH)
+3. **CUDA Toolkit**:
+    - Version 11.8 or higher. For Windows, ensure it integrates with Visual Studio 2022.
+4. **Python**:
+    - Version 3.x with development headers (ensure Python is in PATH and `python-config` or `python3-config` is available for CMake to find it on Linux). On Windows, CMake should find a valid Python installation.
+5. **LibTorch 2.7.0 (C++ API of PyTorch)**:
+    - Setup instructions specific to your OS are below. Ensure you download the version compatible with your CUDA Toolkit version (e.g., cu118 for CUDA 11.8).
+6. **C++ Compiler**:
+    - **Linux**: GCC or Clang with C++17 support.
+    - **Windows**: Visual Studio 2022 (Desktop development with C++ workload).
+7. Other dependencies (GLFW, GLM, TBB, etc.) are handled automatically by CMake via submodules or `find_package`. For TBB on Windows, installing Intel oneAPI Base Toolkit can provide it.
 
 ### Hardware Prerequisites
 1. **NVIDIA GPU** with CUDA support
     - Successfully tested: RTX 4090, RTX A5000, RTX 3090Ti, A100
     - Known issue with RTX 3080Ti on larger datasets (see #21)
-2. Minimum compute capability: 8.0
+2. Minimum recommended compute capability: 7.0 (Volta), 8.0+ (Ampere or newer) preferred for full performance.
 
 > If you successfully run on other hardware, please share your experience in the Discussions section!
 
 ### Build Instructions
+
+#### For Linux
 
 ```bash
 # Clone the repository with submodules
 git clone --recursive https://github.com/MrNeRF/gaussian-splatting-cuda
 cd gaussian-splatting-cuda
 
-# Download and setup LibTorch
-wget https://download.pytorch.org/libtorch/cu118/libtorch-cxx11-abi-shared-with-deps-2.7.0%2Bcu118.zip  
+# Download and setup LibTorch (for CUDA 11.8)
+wget https://download.pytorch.org/libtorch/cu118/libtorch-cxx11-abi-shared-with-deps-2.7.0%2Bcu118.zip
 unzip libtorch-cxx11-abi-shared-with-deps-2.7.0+cu118.zip -d external/
+# It's recommended to move the unzipped 'libtorch' folder to 'external/libtorch' directly
+# e.g., mv external/libtorch-shared-with-deps external/libtorch
 rm libtorch-cxx11-abi-shared-with-deps-2.7.0+cu118.zip
 
 # Build the project
-cmake -B build -DCMAKE_BUILD_TYPE=Release
-cmake --build build -- -j
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc) # or cmake --build . --config Release -- -j$(nproc)
 ```
+
+#### For Windows (Visual Studio 2022)
+
+1.  **Clone the repository with submodules:**
+    ```bash
+    git clone --recursive https://github.com/MrNeRF/gaussian-splatting-cuda
+    cd gaussian-splatting-cuda
+    ```
+
+2.  **Download and setup LibTorch (for CUDA 11.8, Release version):**
+    *   Go to the [PyTorch website](https://pytorch.org/get-started/locally/) and select the appropriate options for your setup:
+        *   PyTorch Build: Stable
+        *   Your OS: Windows
+        *   Package: LibTorch
+        *   Language: C++/Java
+        *   Compute Platform: CUDA 11.8 (or your installed CUDA version, e.g., CUDA 12.1)
+    *   Download the "Release" version zip file. For example, for CUDA 11.8, it might be `libtorch-win-shared-with-deps-2.7.0%2Bcu118.zip`.
+    *   Extract the zip file into the `external/` directory in the project root.
+    *   Rename the extracted folder (e.g., `libtorch-shared-with-deps`) to `libtorch`. So, the path should be `external/libtorch`.
+
+3.  **Configure with CMake:**
+    *   Open CMake GUI or use the command line.
+    *   Set the source code directory to the project root.
+    *   Set the build directory (e.g., `build` inside the project root).
+    *   Click "Configure".
+    *   Specify the generator: "Visual Studio 17 2022".
+    *   Ensure CMake correctly finds CUDA, Python, and Torch.
+        *   If Torch is not found, you might need to set `Torch_DIR` manually in CMake to `external/libtorch/share/cmake/Torch`.
+    *   Set `CMAKE_BUILD_TYPE` to `Release`.
+    *   Click "Generate".
+
+4.  **Build with Visual Studio:**
+    *   Open the generated `.sln` file in the build directory with Visual Studio 2022.
+    *   Select the "Release" configuration.
+    *   Build the `gaussian_splatting_cuda` target (or "Build All").
+    *   The executable will be in the `build/Release` directory.
+
+    Alternatively, from the command line after CMake generation:
+    ```bash
+    cd build
+    cmake --build . --config Release -- -j%NUMBER_OF_PROCESSORS%
+    ```
+    (Replace `%NUMBER_OF_PROCESSORS%` with the number of cores you want to use, e.g., `cmake --build . --config Release -- -j8`)
+
 
 ## LibTorch 2.7.0
 
-This project uses **LibTorch 2.7.0** for optimal performance and compatibility:
+This project uses **LibTorch 2.7.0** for optimal performance and compatibility. Please ensure you download the correct version for your operating system and CUDA setup as described in the build instructions.
 
 - **Enhanced Performance**: Improved optimization and memory management
 - **API Stability**: Latest stable PyTorch C++ API

--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ make -j$(nproc) # or cmake --build . --config Release -- -j$(nproc)
     ```
     (Replace `%NUMBER_OF_PROCESSORS%` with the number of cores you want to use, e.g., `cmake --build . --config Release -- -j8`)
 
+### Windows Build Troubleshooting
+
+*   **LNK1104: cannot open file 'CUDA::nvToolsExt.lib'**:
+    This linker error indicates that the NVIDIA Tools Extension library (`nvToolsExt.lib`) could not be found. This library is typically part of the CUDA Toolkit but might sometimes cause issues if LibTorch expects a version different from your main CUDA Toolkit (e.g., if LibTorch was built against CUDA 11.8 and you have CUDA 12.x installed).
+    *   **Solution provided by users:** Run the installer for an older CUDA Toolkit version (e.g., CUDA 11.8) alongside your existing newer CUDA installation. During the CUDA 11.8 installation, choose "Custom Installation" and select *only* the "Nsight NVTX" component (or similar NVTX related component). Leave all other components unchecked to avoid interfering with your main CUDA Toolkit. This should install the required `.lib` file that LibTorch's CMake configuration is looking for. Ensure your main CUDA toolkit (e.g., 12.x) remains the one primarily configured in your system PATH and for CMake's `find_package(CUDAToolkit)`.
 
 ## LibTorch 2.7.0
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Join our growing community for discussions, support, and updates:
 7. **Git** (for cloning and submodule management).
 8. Other dependencies (GLFW, GLM, TBB, etc.) are handled automatically by CMake.
     - **Submodules**: External libraries like `json`, `args`, `glfw`, `glm`, `glad`, `imgui` are included as git submodules. Ensure these are initialized correctly (see build instructions).
+        - *Note on `json` (nlohmann/json submodule)*: If you encounter CMake policy errors related to this submodule during configuration (especially with older CMake versions or projects), you might need to set `CMAKE_POLICY_VERSION_MINIMUM` to `3.5` or a similar compatible version. In CMake GUI, you can do this by clicking "Add Entry", setting Name: `CMAKE_POLICY_VERSION_MINIMUM`, Type: `STRING`, Value: `3.5`. For command-line CMake, you can add `-DCMAKE_POLICY_VERSION_MINIMUM=3.5`.
     - **TBB (Threading Building Blocks)**:
         - On Linux, CMake will try to find TBB via `find_package`. Ensure it's installed (e.g., `sudo apt-get install libtbb-dev`).
         - On Windows, TBB might need to be installed separately, for example, via the Intel oneAPI Base Toolkit. If CMake cannot find TBB, you may need to set the `TBB_DIR` CMake variable to point to your TBB installation's CMake configuration directory (e.g., `C:/Program Files (x86)/Intel/oneAPI/tbb/latest/lib/cmake/TBB`).

--- a/gsplat/CMakeLists.txt
+++ b/gsplat/CMakeLists.txt
@@ -64,15 +64,34 @@ target_link_libraries(gsplat_backend
 )
 
 # Compile options for both CUDA and C++
-target_compile_options(gsplat_backend PRIVATE
+if(MSVC)
+    target_compile_options(gsplat_backend PRIVATE
+        $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CUDA>>:-G -lineinfo -O0> # Basic debug for CUDA on MSVC
+        $<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:CUDA>>:-O3 --use_fast_math> # Removed GCC-specific flags
+        $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CXX>>:/Od /Zi /EHsc /D_DEBUG /DEBUG_BUILD>
+        $<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:CXX>>:/O2 /EHsc /DNDEBUG /RELEASE_BUILD>
+    )
+    # Add definitions for Windows specific macros, e.g. suppress warnings for CXX
+    target_compile_definitions(gsplat_backend PRIVATE $<$<COMPILE_LANGUAGE:CXX>:_CRT_SECURE_NO_WARNINGS>)
+else()
+    target_compile_options(gsplat_backend PRIVATE
         $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CUDA>>:-O0 -g -G -lineinfo>
         $<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:CUDA>>:-O3 --use_fast_math --expt-relaxed-constexpr -diag-suppress=20012,186>
-        $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CXX>>:-O0 -g>
-        $<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:CXX>>:-O3>
-)
+        $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CXX>>:-O0 -g -DDEBUG_BUILD>
+        $<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:CXX>>:-O3 -DNDEBUG -DRELEASE_BUILD>
+    )
+endif()
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    target_compile_definitions(gsplat_backend PRIVATE _DEBUG DEBUG_BUILD)
-elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
-    target_compile_definitions(gsplat_backend PRIVATE RELEASE_BUILD)
+# The DEBUG_BUILD/RELEASE_BUILD definitions are now handled within the target_compile_options for MSVC
+# and for GCC/Clang. The _DEBUG definition for MSVC Debug is also handled there.
+# The original if(CMAKE_BUILD_TYPE STREQUAL "Debug") block can be removed or commented out
+# if all definitions are handled by the generator expressions above.
+# For clarity, I'll keep the original logic for non-MSVC cases and ensure MSVC specific ones are in its block.
+
+if(NOT MSVC)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        target_compile_definitions(gsplat_backend PRIVATE DEBUG_BUILD) # _DEBUG is often MSVC specific
+    elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
+        target_compile_definitions(gsplat_backend PRIVATE RELEASE_BUILD)
+    endif()
 endif()

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -30,11 +30,10 @@ namespace gs {
                 char executablePathWindows[MAX_PATH];
                 GetModuleFileNameA(nullptr, executablePathWindows, MAX_PATH);
                 std::filesystem::path executablePath = std::filesystem::path(executablePathWindows);
-                std::filesystem::path parentDir = executablePath.parent_path().parent_path().parent_path();
 #else
                 std::filesystem::path executablePath = std::filesystem::canonical("/proc/self/exe");
-                std::filesystem::path parentDir = executablePath.parent_path().parent_path();
 #endif
+                std::filesystem::path parentDir = executablePath.parent_path().parent_path();
                 return parentDir / "parameter" / filename;
             }
 


### PR DESCRIPTION
1. Enabled Windows Compilation Support (Initial CMake Modifications):

Adapted the root CMakeLists.txt and gsplat/CMakeLists.txt for Windows (MSVC compatibility).
Handled compiler flags: Removed Linux-specific flags and added MSVC equivalents (e.g., /EHsc, optimization flags, debug symbols).
Addressed library linking: Conditionally linked the dl library (Unix only).
Reviewed and adjusted CUDA compilation flags for MSVC.
Added logic to copy TBB DLLs to the output directory on Windows, similar to how Torch DLLs were handled.
Reviewed external/CMakeLists.txt and include/config.h.in, confirming they were largely suitable for cross-platform builds without major changes from this effort.
Performed a static code review for common Linux-specific patterns in C++/CUDA source files, finding that included third-party libraries (indicators.hpp, stb_image.h) already managed platform differences well.
2. Documentation Updates (README.md):

Comprehensive Build Instructions: Added detailed build instructions for both Linux and Windows (Visual Studio 2022).
Submodule Initialization: Emphasized the importance of git submodule update --init --recursive and added it as a clear first step for all platforms.
TBB Dependency Clarification: Provided more guidance on installing and configuring TBB, especially for Windows users (e.g., suggesting Intel oneAPI Base Toolkit and setting TBB_DIR).
CMake Policy Note for json: Added a troubleshooting tip for potential CMake policy errors with the nlohmann/json submodule, suggesting how to set CMAKE_POLICY_VERSION_MINIMUM.
NVTX Linker Error Troubleshooting: Included a specific solution for the LNK1104: cannot open file 'CUDA::nvToolsExt.lib' error on Windows, involving a custom installation of the NVTX component from an older CUDA Toolkit (e.g., 11.8) to satisfy LibTorch's expectations.