### PR TITLE
Reduce GPU usage by calling backward per loss

### DIFF
--- a/include/core/trainer.hpp
+++ b/include/core/trainer.hpp
@@ -60,11 +60,17 @@ namespace gs {
         // Returns true if training should continue
         bool train_step(int iter, Camera* cam, torch::Tensor gt_image, RenderMode render_mode);
 
-        // Protected method for computing loss
-        torch::Tensor compute_loss(const RenderOutput& render_output,
-                                   const torch::Tensor& gt_image,
-                                   const SplatData& splatData,
-                                   const param::OptimizationParameters& opt_params);
+        // Protected methods for computing loss
+        torch::Tensor compute_photometric_loss(const RenderOutput& render_output,
+                                               const torch::Tensor& gt_image,
+                                               const SplatData& splatData,
+                                               const param::OptimizationParameters& opt_params);
+        torch::Tensor compute_scale_reg_loss(const SplatData& splatData,
+                                             const param::OptimizationParameters& opt_params);
+        torch::Tensor compute_opacity_reg_loss(const SplatData& splatData,
+                                               const param::OptimizationParameters& opt_params);
+        torch::Tensor compute_bilateral_grid_tv_loss(const std::unique_ptr<gs::BilateralGrid>& bilateral_grid,
+                                                     const param::OptimizationParameters& opt_params);
 
         void initialize_bilateral_grid();
 


### PR DESCRIPTION
Closes #147 


## Test
The memory-usage reduction was measured by polling `nvidia-smi` at one-second intervals using a shell script. 

<details>
<summary>
<code>monitor.sh</code> 
</summary>
<p>

```bash
#!/bin/bash
#
# monitor.sh - Monitor GPU memory usage of a command and log it to a file

set -euo pipefail

# -------------------------------------------------------------------
# Usage check
# -------------------------------------------------------------------
if [ "${#}" -lt 3 ]; then
  printf 'Usage: %s INTERVAL_SEC OUTPUT_FILE -- COMMAND [ARGS...]\n' "$(basename "${0}")" >&2
  exit 1
fi

readonly interval="${1}"
readonly outfile="${2}"
shift 2

# The command to monitor is passed as arguments after "--"
if [ "${1}" = "--" ]; then
  shift
fi
readonly cmd=( "${@}" )

# -------------------------------------------------------------------
# Check required tools
# -------------------------------------------------------------------
for tool in nvidia-smi date awk grep; do
  if ! command -v "${tool}" >/dev/null 2>&1; then
    printf 'Error: %s not found in PATH\n' "${tool}" >&2
    exit 1
  fi
done

# -------------------------------------------------------------------
# Initialize output file (header row)
# -------------------------------------------------------------------
if [ ! -e "${outfile}" ]; then
  printf 'timestamp,memory_MiB\n' > "${outfile}"
fi

# -------------------------------------------------------------------
# Start the command in the background
# -------------------------------------------------------------------
"${cmd[@]}" &
readonly pid=$!

printf 'Started process PID=%s: %s\n' "${pid}" "${cmd[*]}"

# -------------------------------------------------------------------
# Loop to monitor GPU memory usage
# -------------------------------------------------------------------
while kill -0 "${pid}" 2>/dev/null; do
  # Get the GPU memory usage in MiB for the specific PID
  memory=$(
    nvidia-smi \
      --query-compute-apps=pid,used_memory \
      --format=csv,noheader,nounits \
    | grep "^${pid}," \
    | awk -F', ' '{ print $2 }' \
    || printf '0'
  )

  timestamp=$(date '+%Y-%m-%dT%H:%M:%S%z')
  printf '%s,%s\n' "${timestamp}" "${memory}" >> "${outfile}"

  sleep "${interval}"
done

wait "${pid}"
exit $?

```

</p>
</details> 

With the script `monitor.sh`, I ran:

```bash
./monitor.sh 1 memory.csv -- ./build/gaussian_splatting_cuda -d tandt_db/db/drjohnson/ -o output
```

The test scene was **Dr. Johnson** from [tandt_db](https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/datasets/input/tandt_db.zip).

## Result

### Memory Usage

For memory usage reduction, see https://github.com/MrNeRF/gaussian-splatting-cuda/issues/147#issuecomment-3029237562.

When the `--bilateral-grid` flag is enabled, the result looks like this:

<img src="https://github.com/user-attachments/assets/02337b17-a8ef-4fca-8c60-eaa75ced77fb" width="500" />


### Rendering Quality

| Change    | PSNR          | SSIM         | LPIPS        | Num Gaussians |
| --------- | ------------- | ------------ | ------------ | ------------- |
| before   | 29.9167     | 0.9158     | 0.3267     | 1000000       |
| after  | 29.8000     | 0.9147    | 0.3275     | 1000000       |

Although the rendering quality appears slightly reduced, it’s unclear whether this degradation is caused by the current change or by unrelated factors (e.g., random variation).


## Other

The plots above were produced by this Python script:

<details>
<summary>
<code>plot.py</code> 
</summary>
<p>

```python
"""Plot memory consumption over time.

Usage:
    uv run plot.py --original original.csv --modified modified.csv
"""

# /// script
# dependencies = [
#     "matplotlib>=3.10.3",
#     "pandas>=2.3.0",
#     "seaborn>=0.13.2",
# ]
# ///

import argparse
import pathlib

import matplotlib.pyplot as plt
import pandas as pd
import seaborn as sns

sns.set_theme()


class _Args(argparse.Namespace):
    """Command line arguments for the script."""

    original: str
    """Path to the original implementation's result."""

    modified: str
    """Path to the modified implementation's result."""


def _load_data(file_path: pathlib.Path) -> pd.DataFrame:
    """Load CSV data and parse the timestamp column."""
    return pd.read_csv(file_path, parse_dates=["timestamp"])


def _calculate_elapsed_time(dataframe: pd.DataFrame) -> pd.DataFrame:
    """Calculate elapsed time in seconds for the given dataframe.

    Parameters
    ----------
    dataframe : pd.DataFrame
        DataFrame containing a 'timestamp' column.

    Returns
    -------
    pd.DataFrame
        DataFrame with an additional 'elapsed_s' column representing elapsed time in
        seconds.
    """
    elapsed: pd.Series = dataframe["timestamp"] - dataframe["timestamp"].iloc[0]
    dataframe["elapsed_s"] = elapsed.dt.total_seconds()
    return dataframe


def _parse_args() -> _Args:
    """Parse command line arguments."""
    parser = argparse.ArgumentParser(description="Plot memory consumption over time.")
    parser.add_argument(
        "--original",
        "-o",
        type=str,
        help="Path to the result of the original implementation.",
    )
    parser.add_argument(
        "--modified",
        "-m",
        type=str,
        help="Path to the result of the modified implementation.",
    )
    return parser.parse_args(namespace=_Args())


def _main() -> None:
    """Main function to execute the script."""
    args: _Args = _parse_args()

    # Load data
    df1: pd.DataFrame = _load_data(pathlib.Path(args.original))
    df2: pd.DataFrame = _load_data(pathlib.Path(args.modified))

    # Calculate elapsed time
    df1 = _calculate_elapsed_time(df1)
    df2 = _calculate_elapsed_time(df2)

    # Plotting
    fig, ax = plt.subplots(figsize=(10, 6))
    ax.plot(df1["elapsed_s"], df1["memory_MiB"], label="All at once")
    ax.plot(df2["elapsed_s"], df2["memory_MiB"], label="Separately")

    # Labels and title
    ax.set_xlabel("Elapsed Time (s)")
    ax.set_ylabel("Memory (MiB)")
    ax.set_title("Memory Consumption Over Elapsed Time")
    ax.legend()

    fig.tight_layout()
    plt.show()


if __name__ == "__main__":
    _main()

```

</p>
</details> 


With [uv](https://docs.astral.sh/uv/) installed, this script `plot.py` can be run as follows:

```bash
uv run plot.py --original before.csv --modified after.csv
```

