### PR TITLE
camera view modification

### DIFF
--- a/include/visualizer/viewport.hpp
+++ b/include/visualizer/viewport.hpp
@@ -55,7 +55,7 @@ class Viewport {
                 0.0f,               0.0f,              1.0f
             );
 
-            R = R*rot_z ;
+            R = R*rot_z;
 
         }
 

--- a/include/visualizer/viewport.hpp
+++ b/include/visualizer/viewport.hpp
@@ -41,7 +41,7 @@ class Viewport {
             float p = -delta.y * rotateCenterSpeed;
             glm::mat3 Ry = glm::mat3(glm::rotate(glm::mat4(1.0f), y, R[1]));
             glm::mat3 Rp = glm::mat3(glm::rotate(glm::mat4(1.0f), p, R[0]));
-            auto U=Rp*Ry;
+            auto U = Rp * Ry;
             t = U*t;
             R = U*R ;
             prePos = pos;

--- a/include/visualizer/viewport.hpp
+++ b/include/visualizer/viewport.hpp
@@ -16,6 +16,8 @@ class Viewport {
 
         float zoomSpeed = 1.0f;
         float rotateSpeed = 0.001f;
+        float rotateCenterSpeed = 0.002f;
+        float rotateRollSpeed = 0.01f;
         float translateSpeed = 0.001f;
 
         glm::mat3 R = glm::mat3(1.0f);
@@ -31,6 +33,30 @@ class Viewport {
             glm::mat3 Rp = glm::mat3(glm::rotate(glm::mat4(1.0f), p, R[0]));
             R = Rp * Ry * R;
             prePos = pos;
+        }
+
+        void rotate_around_center(const glm::vec2& pos) {
+            glm::vec2 delta = pos - prePos;
+            float y = +delta.x * rotateCenterSpeed;
+            float p = -delta.y * rotateCenterSpeed;
+            glm::mat3 Ry = glm::mat3(glm::rotate(glm::mat4(1.0f), y, R[1]));
+            glm::mat3 Rp = glm::mat3(glm::rotate(glm::mat4(1.0f), p, R[0]));
+            auto U=Rp*Ry;
+            t = U*t;
+            R = U*R ;
+            prePos = pos;
+        }
+
+        void rotate_roll(float diff) {
+            float ang_rad = diff*rotateRollSpeed;
+            glm::mat3 rot_z = glm::mat3(
+                glm::cos(ang_rad), -glm::sin(ang_rad), 0.0f,
+                glm::sin(ang_rad),  glm::cos(ang_rad), 0.0f,
+                0.0f,               0.0f,              1.0f
+            );
+
+            R = R*rot_z ;
+
         }
 
         void translate(const glm::vec2& pos) {

--- a/include/visualizer/viewport.hpp
+++ b/include/visualizer/viewport.hpp
@@ -43,7 +43,7 @@ class Viewport {
             glm::mat3 Rp = glm::mat3(glm::rotate(glm::mat4(1.0f), p, R[0]));
             auto U = Rp * Ry;
             t = U*t;
-            R = U*R ;
+            R = U*R;
             prePos = pos;
         }
 

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -171,7 +171,7 @@ namespace gs {
             // 'R' key is currently pressed
             detail_->viewport_.camera.rotate_roll(delta);
         }
-        else{
+        else {
             detail_->viewport_.camera.zoom(delta);
         }
 

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -174,7 +174,6 @@ namespace gs {
         else {
             detail_->viewport_.camera.zoom(delta);
         }
-
     }
 
     void ViewerDetail::run() {

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -138,7 +138,7 @@ namespace gs {
         if (detail_->any_window_active)
             return;
 
-        if ((button == GLFW_MOUSE_BUTTON_LEFT || button == GLFW_MOUSE_BUTTON_RIGHT) && action == GLFW_PRESS) {
+        if ((button == GLFW_MOUSE_BUTTON_LEFT || button == GLFW_MOUSE_BUTTON_RIGHT || button == GLFW_MOUSE_BUTTON_MIDDLE) && action == GLFW_PRESS) {
             double xpos, ypos;
             glfwGetCursorPos(window, &xpos, &ypos);
             detail_->viewport_.camera.initScreenPos(glm::vec2(xpos, ypos));
@@ -154,6 +154,9 @@ namespace gs {
         } else if (glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_RIGHT) == GLFW_PRESS) {
             detail_->viewport_.camera.rotate(glm::vec2(x, y));
         }
+        else if (glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_MIDDLE) == GLFW_PRESS) {
+            detail_->viewport_.camera.rotate_around_center(glm::vec2(x, y));
+        }
     }
 
     void ViewerDetail::scrollCallback(GLFWwindow* window, double xoffset, double yoffset) {
@@ -164,7 +167,14 @@ namespace gs {
         if (std::abs(delta) < 1.0e-2f)
             return;
 
-        detail_->viewport_.camera.zoom(delta);
+        if (glfwGetKey(window, GLFW_KEY_R) == GLFW_PRESS) {
+            // 'R' key is currently pressed
+            detail_->viewport_.camera.rotate_roll(delta);
+        }
+        else{
+            detail_->viewport_.camera.zoom(delta);
+        }
+
     }
 
     void ViewerDetail::run() {


### PR DESCRIPTION
 inserted rotation around center (middle mouse+drag) and roll rotation ('r' + wheel)
 
 I find the current navigation quite difficult. 
 
 I added a new ability to rotate the camera around the center of the model (mouse 3 + grag) 
 this is inspired from instant-ngp , 
 
 after this rotation you might want to fix the camera roll , so i added 'R' + scroll  to rotating around the roll axis.
 
 hope you will find that helping ( it certainly helped me :) ). 
 