### PR TITLE
Small papercuts

### DIFF
--- a/include/core/parameters.hpp
+++ b/include/core/parameters.hpp
@@ -43,7 +43,7 @@ namespace gs {
             float bilateral_grid_lr = 2e-3;
             float tv_loss_weight = 10.0f;
 
-            int steps_scaler = 1;
+            float steps_scaler = -1;
             bool selective_adam = false; // Use Selective Adam optimizer
         };
 

--- a/include/core/parameters.hpp
+++ b/include/core/parameters.hpp
@@ -30,6 +30,7 @@ namespace gs {
             int max_cap = 1000000;
             std::vector<size_t> eval_steps = {7'000, 30'000}; // Steps to evaluate the model
             std::vector<size_t> save_steps = {7'000, 30'000}; // Steps to save the model
+            bool skip_intermediate_saving = false;            // Skip saving intermediate results and only save final output
             bool enable_eval = false;                         // Only evaluate when explicitly enabled
             bool enable_save_eval_images = false;             // Save during evaluation images
             bool enable_viz = false;                          // Enable visualization during training
@@ -43,8 +44,8 @@ namespace gs {
             float bilateral_grid_lr = 2e-3;
             float tv_loss_weight = 10.0f;
 
-            float steps_scaler = -1;
-            bool selective_adam = false; // Use Selective Adam optimizer
+            float steps_scaler = -1;        // If < 0, step size scaling is disabled
+            bool selective_adam = false;    // Use Selective Adam optimizer
         };
 
         struct DatasetConfig {

--- a/src/argument_parser.cpp
+++ b/src/argument_parser.cpp
@@ -57,6 +57,7 @@ namespace {
         ::args::Flag selective_adam(parser, "selective_adam", "Enable selective adam", {"selective-adam"});
         ::args::Flag enable_save_eval_images(parser, "save_eval_images", "Save eval images and depth maps", {"save-eval-images"});
         ::args::Flag save_depth(parser, "save_depth", "Save depth maps during training", {"save-depth"});
+        ::args::Flag skip_intermediate_saving(parser, "skip_intermediate", "Skip saving intermediate results and only save final output", {"skip-intermediate"});
 
         // Parse arguments
         try {
@@ -130,6 +131,7 @@ namespace {
         setFlag(enable_viz, opt.enable_viz);
         setFlag(selective_adam, opt.selective_adam);
         setFlag(enable_save_eval_images, opt.enable_save_eval_images);
+        setFlag(skip_intermediate_saving, opt.skip_intermediate_saving);
 
         // Special case: validate render mode
         if (render_mode) {

--- a/src/argument_parser.cpp
+++ b/src/argument_parser.cpp
@@ -46,7 +46,7 @@ namespace {
         ::args::ValueFlag<int> max_cap(parser, "max_cap", "Max Gaussians for MCMC", {"max-cap"});
         ::args::ValueFlag<std::string> images_folder(parser, "images", "Images folder name", {"images"});
         ::args::ValueFlag<int> test_every(parser, "test_every", "Use every Nth image as test", {"test-every"});
-        ::args::ValueFlag<int> steps_scaler(parser, "steps_scaler", "Scale training steps by factor", {"steps-scaler"});
+        ::args::ValueFlag<float> steps_scaler(parser, "steps_scaler", "Scale training steps by factor", {"steps-scaler"});
         ::args::ValueFlag<int> sh_degree_interval(parser, "sh_degree_interval", "SH degree interval", {"sh-degree-interval"});
         ::args::ValueFlag<std::string> render_mode(parser, "render_mode", "Render mode: RGB, D, ED, RGB_D, RGB_ED", {"render-mode"});
 
@@ -147,9 +147,9 @@ namespace {
 
     void apply_step_scaling(gs::param::TrainingParameters& params) {
         auto& opt = params.optimization;
-        const size_t scaler = opt.steps_scaler;
+        const float scaler = opt.steps_scaler;
 
-        if (scaler > 1) {
+        if (scaler > 0) {
             std::cout << "Scaling training steps by factor: " << scaler << std::endl;
 
             opt.iterations *= scaler;

--- a/src/argument_parser.cpp
+++ b/src/argument_parser.cpp
@@ -48,6 +48,8 @@ namespace {
         ::args::ValueFlag<int> test_every(parser, "test_every", "Use every Nth image as test", {"test-every"});
         ::args::ValueFlag<float> steps_scaler(parser, "steps_scaler", "Scale training steps by factor", {"steps-scaler"});
         ::args::ValueFlag<int> sh_degree_interval(parser, "sh_degree_interval", "SH degree interval", {"sh-degree-interval"});
+        ::args::ValueFlag<int> sh_degree(parser, "sh_degree", "Max SH degree [1-3]", {"sh-degree"});
+        ::args::ValueFlag<float> min_opacity(parser, "min_opacity", "Minimum opacity threshold", {"min-opacity"});
         ::args::ValueFlag<std::string> render_mode(parser, "render_mode", "Render mode: RGB, D, ED, RGB_D, RGB_ED", {"render-mode"});
 
         // Optional flag arguments
@@ -124,6 +126,7 @@ namespace {
         setVal(test_every, ds.test_every);
         setVal(steps_scaler, opt.steps_scaler);
         setVal(sh_degree_interval, opt.sh_degree_interval);
+        setVal(sh_degree, opt.sh_degree);
 
         // Flag arguments
         setFlag(use_bilateral_grid, opt.use_bilateral_grid);

--- a/src/colmap_reader.cpp
+++ b/src/colmap_reader.cpp
@@ -8,10 +8,12 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <torch/torch.h>
 #include <unordered_map>
 #include <vector>
 
+namespace fs = std::filesystem;
 namespace F = torch::nn::functional;
 
 // -----------------------------------------------------------------------------
@@ -39,7 +41,6 @@ inline torch::Tensor qvec2rotmat(const torch::Tensor& qraw) {
     R[2][2] = 1 - 2 * (x * x + y * y);
     return R;
 }
-
 
 class Image {
 public:
@@ -389,7 +390,7 @@ read_colmap_cameras(const std::filesystem::path base_path,
             float k2 = out[i]._params[5].item<float>();
             float k3 = out[i]._params[6].item<float>();
             float k4 = out[i]._params[7].item<float>();
-            out[i]._radial_distortion = torch::tensor({k1, k2, k3, k4}, torch::kFloat32);            
+            out[i]._radial_distortion = torch::tensor({k1, k2, k3, k4}, torch::kFloat32);
             out[i]._camera_model_type = gsplat::CameraModelType::FISHEYE;
             break;
         }
@@ -421,16 +422,35 @@ read_colmap_cameras(const std::filesystem::path base_path,
 // -----------------------------------------------------------------------------
 //  Public API functions
 // -----------------------------------------------------------------------------
+
+static fs::path get_sparse_file_path(const fs::path& base, const std::string& filename) {
+    fs::path candidate0 = base / "sparse" / "0" / filename;
+    if (fs::exists(candidate0))
+        return candidate0;
+
+    fs::path candidate = base / "sparse" / filename;
+    if (fs::exists(candidate))
+        return candidate;
+
+    throw std::runtime_error(
+        "Cannot find \"" + filename +
+        "\" in \"" + candidate0.string() + "\" or \"" + candidate.string() + "\"");
+}
+
 PointCloud read_colmap_point_cloud(const std::filesystem::path& filepath) {
-    return read_point3D_binary(filepath / "sparse/0/points3D.bin");
+    fs::path points3d_file = get_sparse_file_path(filepath, "points3D.bin");
+    return read_point3D_binary(points3d_file);
 }
 
 std::tuple<std::vector<CameraData>, torch::Tensor> read_colmap_cameras_and_images(
     const std::filesystem::path& base,
     const std::string& images_folder) {
 
-    auto cams = read_cameras_binary(base / "sparse/0/cameras.bin");
-    auto images = read_images_binary(base / "sparse/0/images.bin");
+    fs::path cams_file = get_sparse_file_path(base, "cameras.bin");
+    fs::path images_file = get_sparse_file_path(base, "images.bin");
+
+    auto cams = read_cameras_binary(cams_file);
+    auto images = read_images_binary(images_file);
 
     return read_colmap_cameras(base, cams, images, images_folder);
 }

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -114,6 +114,7 @@ namespace gs {
                     {"render_mode", defaults.render_mode, "Render mode: RGB, D, ED, RGB_D, RGB_ED"},
                     {"enable_eval", defaults.enable_eval, "Enable evaluation during training"},
                     {"enable_save_eval_images", defaults.enable_save_eval_images, "Save images during evaluation"},
+                    {"skip_intermediate", defaults.skip_intermediate_saving, "Skip saving intermediate results and only save final output"},
                     {"use_bilateral_grid", defaults.use_bilateral_grid, "Enable bilateral grid for appearance modeling"},
                     {"bilateral_grid_X", defaults.bilateral_grid_X, "Bilateral grid X dimension"},
                     {"bilateral_grid_Y", defaults.bilateral_grid_Y, "Bilateral grid Y dimension"},
@@ -293,12 +294,15 @@ namespace gs {
                     params.save_steps.push_back(step.get<size_t>());
                 }
             }
-
+                        
             if (json.contains("enable_eval")) {
                 params.enable_eval = json["enable_eval"];
             }
             if (json.contains("enable_save_eval_images")) {
                 params.enable_save_eval_images = json["enable_save_eval_images"];
+            }
+            if (json.contains("skip_intermediate_saving")) {
+                params.skip_intermediate_saving = json["skip_intermediate_saving"];
             }
             if (json.contains("use_bilateral_grid")) {
                 params.use_bilateral_grid = json["use_bilateral_grid"];
@@ -390,6 +394,7 @@ namespace gs {
             opt_json["save_steps"] = params.optimization.save_steps;
             opt_json["enable_eval"] = params.optimization.enable_eval;
             opt_json["enable_save_eval_images"] = params.optimization.enable_save_eval_images;
+            opt_json["skip_intermediate"] = params.optimization.skip_intermediate_saving;
             opt_json["use_bilateral_grid"] = params.optimization.use_bilateral_grid;
             opt_json["bilateral_grid_X"] = params.optimization.bilateral_grid_X;
             opt_json["bilateral_grid_Y"] = params.optimization.bilateral_grid_Y;

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -301,8 +301,8 @@ namespace gs {
             if (json.contains("enable_save_eval_images")) {
                 params.enable_save_eval_images = json["enable_save_eval_images"];
             }
-            if (json.contains("skip_intermediate_saving")) {
-                params.skip_intermediate_saving = json["skip_intermediate_saving"];
+            if (json.contains("skip_intermediate")) {
+                params.skip_intermediate_saving = json["skip_intermediate"];
             }
             if (json.contains("use_bilateral_grid")) {
                 params.use_bilateral_grid = json["use_bilateral_grid"];

--- a/src/trainer.cpp
+++ b/src/trainer.cpp
@@ -271,10 +271,12 @@ namespace gs {
             }
 
             // Save model at specified steps
-            for (size_t save_step : params_.optimization.save_steps) {
-                if (iter == static_cast<int>(save_step) && iter != params_.optimization.iterations) {
-                    const bool join_threads = (iter == params_.optimization.save_steps.back());
-                    strategy_->get_model().save_ply(params_.dataset.output_path, iter, /*join=*/join_threads);
+            if (!params_.optimization.skip_intermediate_saving) {
+                for (size_t save_step : params_.optimization.save_steps) {
+                    if (iter == static_cast<int>(save_step) && iter != params_.optimization.iterations) {
+                        const bool join_threads = (iter == params_.optimization.save_steps.back());
+                        strategy_->get_model().save_ply(params_.dataset.output_path, iter, /*join=*/join_threads);
+                    }
                 }
             }
 


### PR DESCRIPTION
Small additions that I consider could make the life of the users easier:


**Floating-point Step Scaling**
The --steps-scaler option now accepts floating-point values (including values < 1.0), allowing finer control over step sizes and quality/performance trade-offs.

**Skip Intermediate Saves**
New --skip-intermediate flag prevents writing intermediate .ply files, which speeds up processing when only the final output is needed.

**Flexible COLMAP Sparse Support**
The COLMAP loader now looks for sparse reconstructions both in sparse/0/ (default) and a fallback that looks directly under sparse/. This accommodates datasets with multiple level subfolders or ones copied to the root sparse/ directory.

**Configurable SH Degree & Minimum Opacity**
Exposed sh_degree and min_opacity as parameters (CLI/JSON), giving users precise control over spherical harmonics degree and opacity thresholds during rendering.