### PR TITLE
added shortcuts menu

### DIFF
--- a/include/visualizer/detail.hpp
+++ b/include/visualizer/detail.hpp
@@ -163,9 +163,9 @@ namespace gs {
         bool manual_start_triggered_ = false;
         bool training_started_ = false;
 
-        // shortcuts
-        void renderShortcutsWindow();
-        bool show_shortcuts_window_ = false;
+        // camera controls
+        void renderCameraControlsWindow();
+        bool show_camera_controls_window_ = false;
 
     };
 

--- a/include/visualizer/detail.hpp
+++ b/include/visualizer/detail.hpp
@@ -162,6 +162,11 @@ namespace gs {
         std::chrono::steady_clock::time_point save_start_time_;
         bool manual_start_triggered_ = false;
         bool training_started_ = false;
+
+        // shortcuts
+        void renderShortcutsWindow();
+        bool show_shortcuts_window_ = false;
+
     };
 
 } // namespace gs

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -355,13 +355,13 @@ namespace gs {
                 ImGui::TableNextColumn();
                 ImGui::Text("Local Translate Camera");
                 ImGui::TableNextColumn();
-                ImGui::Text("Right Mouse + Drag");
+                ImGui::Text("Left Mouse + Drag");
 
                 ImGui::TableNextRow();
                 ImGui::TableNextColumn();
                 ImGui::Text("Local Rotate Camera (Pitch/Yaw)");
                 ImGui::TableNextColumn();
-                ImGui::Text("Left Mouse + Drag");
+                ImGui::Text("Right Mouse + Drag");
 
                 ImGui::TableNextRow();
                 ImGui::TableNextColumn();

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -340,13 +340,14 @@ namespace gs {
         ImGui::PushStyleColor(ImGuiCol_TitleBg, ImVec4(0.2f, 0.2f, 0.2f, 1.0f));
         ImGui::PushStyleColor(ImGuiCol_TitleBgActive, ImVec4(0.3f, 0.3f, 0.3f, 1.0f));
 
+
         if (ImGui::Begin("Camera Controls", &show_shortcuts_window_, ImGuiWindowFlags_AlwaysAutoResize)) {
             ImGui::Text("Camera Controls:");
             ImGui::Separator();
 
             // Table for better formatting
             if (ImGui::BeginTable("shortcuts_table", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
-                ImGui::TableSetupColumn("Action", ImGuiTableColumnFlags_WidthFixed, 200.0f);
+                ImGui::TableSetupColumn("Action", ImGuiTableColumnFlags_WidthFixed, 300.0f);
                 ImGui::TableSetupColumn("Control", ImGuiTableColumnFlags_WidthStretch);
                 ImGui::TableHeadersRow();
 
@@ -384,7 +385,6 @@ namespace gs {
             }
 
             ImGui::Separator();
-            ImGui::Text("Tip: Hold the specified mouse button and drag to perform the action.");
         }
         ImGui::End();
         ImGui::PopStyleColor(4);

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -334,6 +334,62 @@ namespace gs {
         screen_renderer_->render(quadShader_, viewport_);
     }
 
+    void GSViewer::renderShortcutsWindow() {
+        ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.15f, 0.15f, 0.15f, 0.9f));
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
+        ImGui::PushStyleColor(ImGuiCol_TitleBg, ImVec4(0.2f, 0.2f, 0.2f, 1.0f));
+        ImGui::PushStyleColor(ImGuiCol_TitleBgActive, ImVec4(0.3f, 0.3f, 0.3f, 1.0f));
+
+        if (ImGui::Begin("Camera Controls", &show_shortcuts_window_, ImGuiWindowFlags_AlwaysAutoResize)) {
+            ImGui::Text("Camera Controls:");
+            ImGui::Separator();
+
+            // Table for better formatting
+            if (ImGui::BeginTable("shortcuts_table", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
+                ImGui::TableSetupColumn("Action", ImGuiTableColumnFlags_WidthFixed, 200.0f);
+                ImGui::TableSetupColumn("Control", ImGuiTableColumnFlags_WidthStretch);
+                ImGui::TableHeadersRow();
+
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::Text("Local Translate Camera");
+                ImGui::TableNextColumn();
+                ImGui::Text("Right Mouse + Drag");
+
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::Text("Local Rotate Camera (Pitch/Yaw)");
+                ImGui::TableNextColumn();
+                ImGui::Text("Left Mouse + Drag");
+
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::Text("Rotate Around Scene Center");
+                ImGui::TableNextColumn();
+                ImGui::Text("Middle Mouse + Drag");
+
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::Text("Zoom");
+                ImGui::TableNextColumn();
+                ImGui::Text("Mouse Scroll");
+
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::Text("Roll Camera");
+                ImGui::TableNextColumn();
+                ImGui::Text("R + Mouse Scroll");
+
+                ImGui::EndTable();
+            }
+
+            ImGui::Separator();
+            ImGui::Text("Tip: Hold the specified mouse button and drag to perform the action.");
+        }
+        ImGui::End();
+        ImGui::PopStyleColor(4);
+    }
+
     void GSViewer::configuration() {
         ImGui_ImplOpenGL3_NewFrame();
         ImGui_ImplGlfw_NewFrame();
@@ -519,8 +575,22 @@ namespace gs {
 
         ImGui::Text("num Splats: %d", num_splats);
 
+        // Show Shortcuts button
+        ImGui::Separator();
+        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.4f, 0.4f, 0.7f, 1.0f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.5f, 0.5f, 0.8f, 1.0f));
+        if (ImGui::Button("Show Shortcuts", ImVec2(-1, 0))) {
+            show_shortcuts_window_ = true;
+        }
+        ImGui::PopStyleColor(2);
+
         ImGui::End();
         ImGui::PopStyleColor();
+
+        // Shortcuts window
+        if (show_shortcuts_window_) {
+            renderShortcutsWindow();
+        }
     }
 
     void GSViewer::draw() {

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -334,19 +334,19 @@ namespace gs {
         screen_renderer_->render(quadShader_, viewport_);
     }
 
-    void GSViewer::renderShortcutsWindow() {
+    void GSViewer::renderCameraControlsWindow() {
         ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.15f, 0.15f, 0.15f, 0.9f));
         ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
         ImGui::PushStyleColor(ImGuiCol_TitleBg, ImVec4(0.2f, 0.2f, 0.2f, 1.0f));
         ImGui::PushStyleColor(ImGuiCol_TitleBgActive, ImVec4(0.3f, 0.3f, 0.3f, 1.0f));
 
 
-        if (ImGui::Begin("Camera Controls", &show_shortcuts_window_, ImGuiWindowFlags_AlwaysAutoResize)) {
+        if (ImGui::Begin("Camera Controls", &show_camera_controls_window_, ImGuiWindowFlags_AlwaysAutoResize)) {
             ImGui::Text("Camera Controls:");
             ImGui::Separator();
 
             // Table for better formatting
-            if (ImGui::BeginTable("shortcuts_table", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
+            if (ImGui::BeginTable("camera_controls_table", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
                 ImGui::TableSetupColumn("Action", ImGuiTableColumnFlags_WidthFixed, 300.0f);
                 ImGui::TableSetupColumn("Control", ImGuiTableColumnFlags_WidthStretch);
                 ImGui::TableHeadersRow();
@@ -575,21 +575,21 @@ namespace gs {
 
         ImGui::Text("num Splats: %d", num_splats);
 
-        // Show Shortcuts button
+        // Show Camera Controls button
         ImGui::Separator();
         ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.4f, 0.4f, 0.7f, 1.0f));
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.5f, 0.5f, 0.8f, 1.0f));
-        if (ImGui::Button("Show Shortcuts", ImVec2(-1, 0))) {
-            show_shortcuts_window_ = true;
+        if (ImGui::Button("Show Camera Controls", ImVec2(-1, 0))) {
+            show_camera_controls_window_ = true;
         }
         ImGui::PopStyleColor(2);
 
         ImGui::End();
         ImGui::PopStyleColor();
 
-        // Shortcuts window
-        if (show_shortcuts_window_) {
-            renderShortcutsWindow();
+        // Camera Controls window
+        if (show_camera_controls_window_) {
+            renderCameraControlsWindow();
         }
     }
 


### PR DESCRIPTION
added shortcut menu  to the main window . for now the shortcuts are:

1. mouse right + drag = local translate the camera
2. mouse left + drag = local rotate the camera in the pitch yaw directions
3. mouse middle + drag = rotate the camera around the scene center
4. scroll = zoom
5. R+scroll = rotate the camera around the roll axis

