### PR TITLE
README: update gfortran to 14 as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,15 +176,17 @@ gcc --version  # Should be 14+ for full C++23 support
 
 # Install GCC 14 (Ubuntu 24.04+)
 sudo apt update
-sudo apt install gcc-14 g++-14
+sudo apt install gcc-14 g++-14 gfortran-14
 
 # Set as default
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 60
 sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 60
+sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-14 60
 
 # Select the gcc/g++-14
 sudo update-alternatives --config gcc
 sudo update-alternatives --config g++ 
+sudo update-alternatives --config gfortran
 ```
 
 ##### Ubuntu 22.04:


### PR DESCRIPTION
Probably not directly related, but I moved up to gcc 14 because of this project, and compilation for other projects were breaking because gfortran was still at the default 13, so I think it's a good idea to mention updating gfortran to 14 as well in the README