### PR TITLE
Use string keys for optimizer state to fix type mismatch

### DIFF
--- a/include/core/gs_utils.hpp
+++ b/include/core/gs_utils.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+#include <sstream>
+
+namespace gs {
+inline std::string get_tensor_key(const void* ptr) {
+    std::stringstream ss;
+    ss << ptr;
+    return ss.str();
+}
+
+}

--- a/src/mcmc.cpp
+++ b/src/mcmc.cpp
@@ -3,6 +3,7 @@
 #include "core/debug_utils.hpp"
 #include "core/parameters.hpp"
 #include "core/rasterizer.hpp"
+#include "core/gs_utils.hpp"
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <exception>
 #include <iostream>
@@ -91,7 +92,7 @@ void MCMC::update_optimizer_for_relocate(torch::optim::Optimizer* optimizer,
     void* param_key = param.unsafeGetTensorImpl();
 
     // Check if optimizer state exists
-    auto state_it = optimizer->state().find(param_key);
+    auto state_it = optimizer->state().find(gs::get_tensor_key(param_key));
     if (state_it == optimizer->state().end()) {
         // No state exists yet - this can happen if optimizer.step() hasn't been called
         // In this case, there's nothing to reset, so we can safely return
@@ -293,7 +294,7 @@ int MCMC::add_new_gs() {
         old_param_keys.push_back(old_param_key);
 
         // Check if state exists
-        auto state_it = _optimizer->state().find(old_param_key);
+        auto state_it = _optimizer->state().find(gs::get_tensor_key(old_param_key));
         if (state_it != _optimizer->state().end()) {
             // Clone the state before modifying - handle both optimizer types
             if (auto* adam_state = dynamic_cast<torch::optim::AdamParamState*>(state_it->second.get())) {
@@ -368,7 +369,7 @@ int MCMC::add_new_gs() {
 
     // Now remove all old states
     for (auto key : old_param_keys) {
-        _optimizer->state().erase(key);
+        _optimizer->state().erase(gs::get_tensor_key(key));
     }
 
     // Update parameters and add new states
@@ -377,7 +378,7 @@ int MCMC::add_new_gs() {
 
         if (saved_states[i]) {
             void* new_param_key = new_params[i]->unsafeGetTensorImpl();
-            _optimizer->state()[new_param_key] = std::move(saved_states[i]);
+            _optimizer->state()[gs::get_tensor_key(new_param_key)] = std::move(saved_states[i]);
         }
     }
 

--- a/src/selective_adam.cpp
+++ b/src/selective_adam.cpp
@@ -1,6 +1,7 @@
 #include "core/selective_adam.hpp"
 #include "Ops.h"
 #include <torch/torch.h>
+#include "core/gs_utils.hpp"
 
 namespace gs {
 
@@ -46,15 +47,15 @@ namespace gs {
                             ") must match visibility mask size (", N, ")");
 
                 // Lazy state initialization
-                auto state_ptr = state_.find(param.unsafeGetTensorImpl());
+                auto state_ptr = state_.find(gs::get_tensor_key(param.unsafeGetTensorImpl()));
                 if (state_ptr == state_.end()) {
                     auto new_state = std::make_unique<AdamParamState>();
                     new_state->step_count = 0;
                     new_state->exp_avg = torch::zeros_like(param, torch::MemoryFormat::Preserve);
                     new_state->exp_avg_sq = torch::zeros_like(param, torch::MemoryFormat::Preserve);
 
-                    state_[param.unsafeGetTensorImpl()] = std::move(new_state);
-                    state_ptr = state_.find(param.unsafeGetTensorImpl());
+                    state_[gs::get_tensor_key(param.unsafeGetTensorImpl())] = std::move(new_state);
+                    state_ptr = state_.find(gs::get_tensor_key(param.unsafeGetTensorImpl()));
                 }
 
                 auto& state = static_cast<AdamParamState&>(*state_ptr->second);


### PR DESCRIPTION
The optimizer state map uses std::string as its key type, but several parts of the code were attempting to use raw TensorImpl* pointers for lookups, insertions, and deletions.

This caused a compilation failure on stricter compilers (e.g., MSVC) due to a type mismatch, as there is no implicit conversion from a pointer to std::string.

This change preserves the original logic of using the tensor's memory address as a unique identifier but corrects the implementation. A new helper function, gs::get_tensor_key(), is introduced to encapsulate the pointer-to-string conversion. It has been placed in a new core/gs_utils.hpp header, which can be used for similar small, shared utility tools in the future.

All optimizer state map accesses in selective_adam.cpp and mcmc.cpp have been updated to use this helper, resolving the compilation error on stricter than gcc compilers.