### PR TITLE
Priority-based input handling 

### DIFF
--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -227,6 +227,18 @@ namespace gs::gui {
         }
     }
 
+    bool GuiManager::wantsInput() const {
+        ImGuiIO& io = ImGui::GetIO();
+        return io.WantCaptureMouse || io.WantCaptureKeyboard;
+    }
+
+    bool GuiManager::isAnyWindowActive() const {
+        return ImGui::IsAnyItemActive() ||
+               ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) ||
+               ImGui::GetIO().WantCaptureMouse ||
+               ImGui::GetIO().WantCaptureKeyboard;
+    }
+
     bool GuiManager::showCropBox() const {
         if (auto* tool_manager = viewer_->getToolManager()) {
             if (auto* crop_tool = dynamic_cast<visualizer::CropBoxTool*>(

--- a/src/visualizer/gui/gui_manager.hpp
+++ b/src/visualizer/gui/gui_manager.hpp
@@ -29,7 +29,8 @@ namespace gs {
             void render();
 
             // State queries
-            bool isAnyWindowActive() const { return ImGui::IsAnyItemActive(); }
+            bool wantsInput() const;
+            bool isAnyWindowActive() const;
             bool showCropBox() const;
             bool useCropBox() const;
 

--- a/src/visualizer/input/camera_controller.cpp
+++ b/src/visualizer/input/camera_controller.cpp
@@ -11,30 +11,47 @@
 
 namespace gs {
 
+    CameraController::~CameraController() {
+        // Clean up our handlers
+        if (input_handler_) {
+            for (auto id : handler_ids_) {
+                input_handler_->removeHandler(id);
+            }
+        }
+    }
+
     void CameraController::connectToInputHandler(InputHandler& input_handler) {
         // Store reference to input handler for checking key states
         input_handler_ = &input_handler;
 
-        // Register all handlers
-        input_handler.addMouseButtonHandler(
-            [this](const InputHandler::MouseButtonEvent& event) {
-                return handleMouseButton(event);
-            });
+        // Register all handlers with Camera priority
+        handler_ids_.push_back(
+            input_handler.addMouseButtonHandler(
+                [this](const InputHandler::MouseButtonEvent& event) {
+                    return handleMouseButton(event);
+                },
+                InputPriority::Camera));
 
-        input_handler.addMouseMoveHandler(
-            [this](const InputHandler::MouseMoveEvent& event) {
-                return handleMouseMove(event);
-            });
+        handler_ids_.push_back(
+            input_handler.addMouseMoveHandler(
+                [this](const InputHandler::MouseMoveEvent& event) {
+                    return handleMouseMove(event);
+                },
+                InputPriority::Camera));
 
-        input_handler.addMouseScrollHandler(
-            [this](const InputHandler::MouseScrollEvent& event) {
-                return handleMouseScroll(event);
-            });
+        handler_ids_.push_back(
+            input_handler.addMouseScrollHandler(
+                [this](const InputHandler::MouseScrollEvent& event) {
+                    return handleMouseScroll(event);
+                },
+                InputPriority::Camera));
 
-        input_handler.addKeyHandler(
-            [this](const InputHandler::KeyEvent& event) {
-                return handleKey(event);
-            });
+        handler_ids_.push_back(
+            input_handler.addKeyHandler(
+                [this](const InputHandler::KeyEvent& event) {
+                    return handleKey(event);
+                },
+                InputPriority::Camera));
     }
 
     void CameraController::publishCameraChanged() {

--- a/src/visualizer/input/camera_controller.hpp
+++ b/src/visualizer/input/camera_controller.hpp
@@ -4,12 +4,14 @@
 #include "input/input_handler.hpp"
 #include "internal/viewport.hpp"
 #include <chrono>
+#include <vector>
 
 namespace gs {
 
     class CameraController {
     public:
         explicit CameraController(Viewport& viewport) : viewport_(viewport) {}
+        ~CameraController();
 
         // Setup input handlers
         void connectToInputHandler(InputHandler& input_handler);
@@ -26,6 +28,9 @@ namespace gs {
 
         Viewport& viewport_;
         InputHandler* input_handler_ = nullptr; // Store reference for key state queries
+
+        // Handler IDs for cleanup
+        std::vector<InputHandler::HandlerId> handler_ids_;
 
         // State
         bool is_panning_ = false;

--- a/src/visualizer/input/input_manager.hpp
+++ b/src/visualizer/input/input_manager.hpp
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <functional>
 #include <memory>
+#include <vector>
 
 namespace gs::visualizer {
 
@@ -35,6 +36,9 @@ namespace gs::visualizer {
 
         GuiActiveCheck gui_active_check_;
         FileDropCallback file_drop_callback_;
+
+        // Handler IDs for cleanup
+        std::vector<InputHandler::HandlerId> gui_handler_ids_;
 
         void setupInputHandlers();
         bool handleFileDrop(const InputHandler::FileDropEvent& event);

--- a/src/visualizer/input/input_priority.hpp
+++ b/src/visualizer/input/input_priority.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <cstdint>
+
+namespace gs {
+
+    // Input priority levels - higher values = higher priority
+    enum class InputPriority : int32_t {
+        Blocked = 10000, // Input is blocked (e.g., during loading)
+        System = 1000,   // System-level shortcuts (e.g., ESC to quit)
+        Modal = 900,     // Modal dialogs that must be addressed
+        GUI = 800,       // Regular GUI elements (ImGui windows, buttons, etc.)
+        Tools = 700,     // Interactive tools (crop box, etc.)
+        Camera = 600,    // Camera controls
+        Scene = 500,     // Scene interaction
+        Default = 0      // Default/fallback priority
+    };
+
+    // Helper to check if one priority should handle before another
+    constexpr bool has_higher_priority(InputPriority a, InputPriority b) {
+        return static_cast<int32_t>(a) > static_cast<int32_t>(b);
+    }
+
+} // namespace gs

--- a/src/visualizer/tools/crop_box_tool.hpp
+++ b/src/visualizer/tools/crop_box_tool.hpp
@@ -23,6 +23,9 @@ namespace gs::visualizer {
         void render(const ToolContext& ctx) override;
         void renderUI(const gs::gui::UIContext& ui_ctx, bool* p_open) override;
 
+        // Input handling
+        void registerInputHandlers(InputHandler& handler) override;
+
         // Crop box specific methods
         std::shared_ptr<gs::RenderBoundingBox> getBoundingBox() { return bounding_box_; }
         bool shouldShowBox() const { return show_crop_box_; }
@@ -38,6 +41,12 @@ namespace gs::visualizer {
         glm::mat4 orthonormalizeRotation(const glm::mat4& matrix);
         static float wrapAngle(float angle);
 
+        // Input handling helpers
+        bool isMouseOverHandle(const glm::dvec2& mouse_pos) const;
+        void startDragging(const glm::dvec2& mouse_pos);
+        void updateDragging(const glm::dvec2& mouse_pos);
+        void stopDragging();
+
         std::shared_ptr<gs::RenderBoundingBox> bounding_box_;
 
         // UI state
@@ -50,6 +59,22 @@ namespace gs::visualizer {
         float rotate_timer_x_ = 0.0f;
         float rotate_timer_y_ = 0.0f;
         float rotate_timer_z_ = 0.0f;
+
+        // Interaction state
+        bool is_dragging_ = false;
+        glm::dvec2 drag_start_pos_;
+        glm::vec3 drag_start_box_min_;
+        glm::vec3 drag_start_box_max_;
+        enum class DragHandle {
+            None,
+            MinX,
+            MinY,
+            MinZ,
+            MaxX,
+            MaxY,
+            MaxZ,
+            Center
+        } current_handle_ = DragHandle::None;
     };
 
 } // namespace gs::visualizer

--- a/src/visualizer/tools/tool_base.hpp
+++ b/src/visualizer/tools/tool_base.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
+#include "input/input_handler.hpp"
+#include "input/input_priority.hpp"
 #include <memory>
 #include <string>
 #include <string_view>
+#include <vector>
 
 // Forward declaration for GLFW
 struct GLFWwindow;
@@ -79,8 +82,20 @@ namespace gs::visualizer {
         virtual void render(const ToolContext& ctx) {}
         virtual void renderUI(const gs::gui::UIContext& ui_ctx, bool* p_open) = 0;
 
+        // Input handling - tools can override these to register handlers
+        virtual void registerInputHandlers(InputHandler& handler) {}
+        virtual void unregisterInputHandlers(InputHandler& handler) {
+            for (auto id : handler_ids_) {
+                handler.removeHandler(id);
+            }
+            handler_ids_.clear();
+        }
+
     protected:
         virtual void onEnabledChanged(bool enabled) {}
+
+        // Store handler IDs for cleanup
+        std::vector<InputHandler::HandlerId> handler_ids_;
 
     private:
         bool enabled_ = false;

--- a/src/visualizer/tools/tool_manager.cpp
+++ b/src/visualizer/tools/tool_manager.cpp
@@ -46,6 +46,11 @@ namespace gs::visualizer {
                 std::println("Failed to initialize tool '{}'", tool_name);
                 return false;
             }
+
+            // Register input handlers
+            if (auto* input_handler = visualizer_->input_manager_->getInputHandler()) {
+                tool->registerInputHandlers(*input_handler);
+            }
         }
 
         active_tools_.push_back(std::move(tool));
@@ -64,6 +69,11 @@ namespace gs::visualizer {
                                [&](const auto& tool) { return tool->getName() == tool_name; });
 
         if (it != active_tools_.end()) {
+            // Unregister input handlers
+            if (auto* input_handler = visualizer_->input_manager_->getInputHandler()) {
+                (*it)->unregisterInputHandlers(*input_handler);
+            }
+
             (*it)->shutdown();
             active_tools_.erase(it);
 
@@ -76,6 +86,13 @@ namespace gs::visualizer {
     }
 
     void ToolManager::removeAllTools() {
+        // Unregister all input handlers
+        if (auto* input_handler = visualizer_->input_manager_->getInputHandler()) {
+            for (auto& tool : active_tools_) {
+                tool->unregisterInputHandlers(*input_handler);
+            }
+        }
+
         for (auto& tool : active_tools_) {
             tool->shutdown();
         }
@@ -105,11 +122,23 @@ namespace gs::visualizer {
             if (!tool->initialize(*this)) {
                 std::println("Warning: Failed to initialize tool '{}'", tool->getName());
             }
+
+            // Register input handlers
+            if (auto* input_handler = visualizer_->input_manager_->getInputHandler()) {
+                tool->registerInputHandlers(*input_handler);
+            }
         }
         initialized_ = true;
     }
 
     void ToolManager::shutdown() {
+        // Unregister all input handlers
+        if (auto* input_handler = visualizer_->input_manager_->getInputHandler()) {
+            for (auto& tool : active_tools_) {
+                tool->unregisterInputHandlers(*input_handler);
+            }
+        }
+
         for (auto& tool : active_tools_) {
             tool->shutdown();
         }
@@ -173,12 +202,25 @@ namespace gs::visualizer {
         tools::ToolEnabled::when([this](const auto& e) {
             if (auto* tool = getTool(e.tool_name)) {
                 tool->setEnabled(true);
+
+                // Re-register input handlers when enabled
+                if (initialized_) {
+                    if (auto* input_handler = visualizer_->input_manager_->getInputHandler()) {
+                        tool->unregisterInputHandlers(*input_handler); // Clear old ones first
+                        tool->registerInputHandlers(*input_handler);
+                    }
+                }
             }
         });
 
         tools::ToolDisabled::when([this](const auto& e) {
             if (auto* tool = getTool(e.tool_name)) {
                 tool->setEnabled(false);
+
+                // Unregister input handlers when disabled
+                if (auto* input_handler = visualizer_->input_manager_->getInputHandler()) {
+                    tool->unregisterInputHandlers(*input_handler);
+                }
             }
         });
     }


### PR DESCRIPTION
Priority-based input handling system that solves the issue where mouse interactions were affecting both the UI and the 3D scene simultaneously. 

The system now processes input events in order of priority: GUI widgets get first chance to consume events, followed by tools like the crop box, and finally the camera controls.

Fixes https://github.com/MrNeRF/gaussian-splatting-cuda/issues/221!