### PR TITLE
Bounty Solution (2.4x speedup)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ configure_file(
 )
 
 add_subdirectory(gsplat)
+add_subdirectory(fastgs)
 
 # =============================================================================
 # HOST LIBRARY - Compiled with g++ (fast!)
@@ -83,12 +84,15 @@ set(HOST_SOURCES
         src/trainer.cpp
         src/argument_parser.cpp
         src/rasterizer.cpp
+        src/fast_rasterizer.cpp
         src/metrics.cpp
         src/rasterizer_autograd.cpp
+        src/fast_rasterizer_autograd.cpp
         src/viewer.cpp
         src/external/tinyply.cpp
         src/bilateral_grid.cpp
         src/selective_adam.cpp
+        src/fused_adam.cpp
 )
 
 add_library(gaussian_host STATIC ${HOST_SOURCES})
@@ -99,6 +103,7 @@ target_include_directories(gaussian_host
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         ${CMAKE_CURRENT_BINARY_DIR}/include  # For generated config.h
         ${CMAKE_CURRENT_SOURCE_DIR}/gsplat  # Add gsplat headers
+        ${CMAKE_CURRENT_SOURCE_DIR}/fastgs  # Add fastgs headers
         ${CUDAToolkit_INCLUDE_DIRS}         # Add CUDA headers for interop
         PRIVATE
         ${Python3_INCLUDE_DIRS}
@@ -117,6 +122,7 @@ target_link_libraries(gaussian_host
         taywee::args
         Python3::Python
         gsplat_backend  # Link to gsplat
+        fastgs_backend  # Link to fastgs
         ${OPENGL_LIBRARIES}
         CUDA::cudart    # Add CUDA runtime for interop
 )
@@ -251,6 +257,7 @@ target_include_directories(${PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         ${CMAKE_CURRENT_BINARY_DIR}/include  # For generated config.h
         ${CMAKE_CURRENT_SOURCE_DIR}/gsplat
+        ${CMAKE_CURRENT_SOURCE_DIR}/fastgs
         ${Python3_INCLUDE_DIRS}
         ${CUDAToolkit_INCLUDE_DIRS}
         ${OPENGL_INCLUDE_DIRS}
@@ -261,6 +268,7 @@ set(MAIN_LINK_LIBRARIES
         gaussian_host
         gaussian_kernels
         gsplat_backend
+        fastgs_backend
         Python3::Python
         ${OPENGL_LIBRARIES}
         CUDA::cudart
@@ -330,6 +338,7 @@ endfunction()
 configure_build_type(gaussian_host)
 configure_build_type(gaussian_kernels)
 configure_build_type(gsplat_backend)
+configure_build_type(fastgs_backend)
 if(CUDA_GL_INTEROP_FOUND AND TARGET gaussian_visualizer)
     configure_build_type(gaussian_visualizer)
 endif()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-- # 3D Gaussian Splatting for Real-Time Radiance Field Rendering - C++ and CUDA Implementation
+# 3D Gaussian Splatting for Real-Time Radiance Field Rendering - C++ and CUDA Implementation
 
 [![Discord](https://img.shields.io/badge/Discord-Join%20Us-7289DA?logo=discord&logoColor=white)](https://discord.gg/TbxJST2BbC)
 [![Website](https://img.shields.io/badge/Website-mrnerf.com-blue)](https://mrnerf.com)
@@ -13,6 +13,93 @@ Reduce training time by half and win **the $1300 prize**!
 Details here: [Issue #135](https://github.com/MrNeRF/gaussian-splatting-cuda/issues/135)
 
 This competition is sponsored by [@vincentwoo](https://github.com/vincentwoo), [@mazy1998](https://github.com/mazy1998), and myself - each contributing **$300**. [@toshas](https://github.com/toshas) and [@ChrisAtKIRI](https://x.com/ChrisAtKIRI) are each contributing **$200**.
+
+# Bounty Solution
+
+This is a solution for [Issue #135](https://github.com/MrNeRF/gaussian-splatting-cuda/issues/135).
+It implements improvements that reduce the training from the original 49m 50s to **20m 30s**, a speedup by over **2.4x**.
+To get the time below 20 minutes, I also added an *optional* trick that sacrifices some quality to get the time down to *19m 27s*.
+
+## Changes
+
+The key changes can be summarized as follows:
+
+### New Rasterizer
+- Instead of the modular gsplat implementation, the new implementation tries to use as few CUDA kernels as possible.
+- I redid all the math for the forward and backward pass to skip all unnecessary computations.
+- All activation functions of the Gaussians' parameters are fused into the respective kernels of the forward and backward pass.
+- I implemented an improved version of the kernel for the blending backward pass based on Taming 3DGS.
+- I separated the sorting into depth and tile sorting passes similar to how it is done in Splatshop.
+- I integrated tile-based culling and load balancing based on StopThePop.
+- Also see `fastgs/rasterization/README.md`
+
+### MCMC Densification
+- After every training iteration, MCMC adds noise to the position of each Gaussian. I fused the required operations into a single kernel.
+- The functions for adding and relocating Gaussians could be fused too, but because they do not happen that often during training, the benefit would be small. Therefore, I did not do so and only fixed a few inefficiencies in the libtorch implementation.
+- Gaussians are now also "dead" when the quaternion used to represent their rotation has a squared norm below `1e-8` as optimization and rendering would then be numerically unstable anyway. The new rasterizer also culls such Gaussians during training.
+- Like most 3DGS implementations, the old implementation used to call the libtorch equivalent of `torch.cuda.empty_cache()` after every densification step to solve memory fragmentation issues. This slightly slows down training as temporary memory is first freed and then reallocated. Enabling the torch memory allocator's setting `expandable_segments:True` allows to get rid of this.
+- I removed the `abs()` calls in the opacity and scale regularization losses as they are unnecessary because the Gaussians' opacity and scale are always positive after applying the respective activations.
+
+### Optimizer
+- The libtorch Adam implementation is slow because it launches all operations for each update step as separate CUDA kernels. I implemented a fused version of the Adam optimizer step that is significantly faster.
+- During the first 1000 iterations, the higher-degree SH coefficients will not be used and therefore always have zero gradients. Therefore, the optimizer step for those can be skipped for a small speedup.
+- (optional) Between iteration 1000 and 25000, the expensive update for higher-degree SH coefficients can be batched over two iterations to achieve a small speed up. This is disabled by default as it seems to slightly reduce quality in my tests.
+
+### Data Loading
+- The torch dataloader was re-created after every epoch. Now only the random sampler is reset, which avoids unnecessary overhead.
+- Image normalization to the [0, 1] range was done on the CPU. Doing it after uploading to the GPU is much faster.
+- Images were always loaded from disk, which is actually not that bad with a torch dataloader that uses multiple worker threads, but it has some overhead. Now, heuristics are used to determine whether the dataset fits into GPU memory. If yes, images are cached in VRAM.
+- Since the VRAM needed for storing the view matrices and camera positions for all views is negligible, they are now precomputed and stored in VRAM. Example: 10k views -> 0.76 MB (could be lower as I store the full 4x4 view matrix instead of just the relevant 3x4 part)
+
+## Evaluation
+
+Timings are quite consistent across runs as long as one does not touch the PC during benchmarking.
+```
+=========================================
+BENCHMARK SUMMARY
+=========================================
+garden         : 00h 02m 28s
+bicycle        : 00h 02m 14s
+stump          : 00h 02m 20s
+bonsai         : 00h 03m 17s
+counter        : 00h 03m 35s
+kitchen        : 00h 03m 42s
+room           : 00h 02m 54s
+-----------------------------------------
+Total time: 0h 20m 30s
+=========================================
+```
+With the optional SH trick enabled, training is slightly faster and the total is below 20 minutes:
+```
+=========================================
+BENCHMARK SUMMARY
+=========================================
+garden         : 00h 02m 18s
+bicycle        : 00h 02m 06s
+stump          : 00h 02m 11s
+bonsai         : 00h 03m 07s
+counter        : 00h 03m 25s
+kitchen        : 00h 03m 35s
+room           : 00h 02m 45s
+-----------------------------------------
+Total time: 0h 19m 27s
+=========================================
+```
+
+Here are the average quality metrics that I got with the original implementation and the new one without and with the optional SH trick enabled.
+Note that metric computation still uses gsplat to render the images. This highlights that the new rasterizer used during training is not required during inference to obtain high quality.
+
+| Version              | PSNR      | SSIM     | LPIPS    |
+|----------------------|-----------|----------| -------- |
+| original             | 29.235601 | 0.879749 | 0.227879 |
+| solution             | 29.277397 | 0.879477 | 0.228021 |
+| solution w/ SH trick | 29.226835 | 0.879472 | 0.228022 |
+
+I spent a lot of time on making sure the new implementation does not reduce quality.
+Note that the results in this table do not confirm that the new implementation is strictly better than the original one.
+There are small differences in terms of how things are computed in a numerically stable manner in the rasterizer.
+However, this did not make a measurable difference in practice.
+The main problem when repeatedly testing both the original and the new implementation is that metrics fluctuate between runs making it impossible to tell which implementation achieves better quality.
 
 ## Agenda (this summer)
 1. Improve the viewer, i.e., better camera controls, more interactive features.

--- a/fastgs/CMakeLists.txt
+++ b/fastgs/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 3.24...3.30)
+
+# TODO: This file is a bit of a mess and needs to be cleaned up.
+
+# Get torch from parent
+if(NOT DEFINED TORCH_INCLUDE_DIRS)
+    find_package(Torch REQUIRED)
+endif()
+
+# All fastgs sources together
+set(FASTGS_SOURCES
+        # rasterizer
+        ${CMAKE_CURRENT_SOURCE_DIR}/rasterization/src/rasterization_api.cu
+        ${CMAKE_CURRENT_SOURCE_DIR}/rasterization/src/forward.cu
+        ${CMAKE_CURRENT_SOURCE_DIR}/rasterization/src/backward.cu
+        # optimizer
+        ${CMAKE_CURRENT_SOURCE_DIR}/optimizer/src/adam_api.cu
+        ${CMAKE_CURRENT_SOURCE_DIR}/optimizer/src/adam.cu
+)
+
+# One unified library
+add_library(fastgs_backend STATIC ${FASTGS_SOURCES})
+
+set_target_properties(fastgs_backend PROPERTIES
+        CUDA_ARCHITECTURES native
+        CUDA_SEPARABLE_COMPILATION ON
+        POSITION_INDEPENDENT_CODE ON
+        CUDA_RESOLVE_DEVICE_SYMBOLS ON
+)
+
+target_include_directories(fastgs_backend
+        PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/rasterization/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/optimizer/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/utils
+        ${CMAKE_SOURCE_DIR}/include
+        ${CUDAToolkit_INCLUDE_DIRS}
+        ${OPENGL_INCLUDE_DIRS}
+        ${TORCH_INCLUDE_DIRS}
+        PRIVATE
+        ${Python3_INCLUDE_DIRS}
+)
+
+target_link_libraries(fastgs_backend
+        PUBLIC
+        CUDA::cudart
+        CUDA::curand
+        CUDA::cublas
+        ${TORCH_LIBRARIES}
+)
+
+# Compile options for both CUDA and C++
+target_compile_options(fastgs_backend PRIVATE
+        $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CUDA>>:-O0 -g -G -lineinfo>
+        $<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:CUDA>>:-O3 --use_fast_math --expt-relaxed-constexpr -diag-suppress=20012,186>
+        $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CXX>>:-O0 -g>
+        $<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:CXX>>:-O3>
+)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_definitions(fastgs_backend PRIVATE _DEBUG DEBUG_BUILD)
+elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
+    target_compile_definitions(fastgs_backend PRIVATE RELEASE_BUILD)
+endif()

--- a/fastgs/optimizer/include/adam.h
+++ b/fastgs/optimizer/include/adam.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace fast_gs::optimizer {
+
+    void adam_step(
+        float* param,
+        float* exp_avg,
+        float* exp_avg_sq,
+        const float* param_grad,
+        const int n_elements,
+        const float lr,
+        const float beta1,
+        const float beta2,
+        const float eps,
+        const float bias_correction1_rcp,
+        const float bias_correction2_sqrt_rcp);
+
+}

--- a/fastgs/optimizer/include/adam_api.h
+++ b/fastgs/optimizer/include/adam_api.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <torch/extension.h>
+
+namespace fast_gs::optimizer {
+
+    void adam_step_wrapper(
+        torch::Tensor& param,
+        torch::Tensor& exp_avg,
+        torch::Tensor& exp_avg_sq,
+        const torch::Tensor& param_grad,
+        const float lr,
+        const float beta1,
+        const float beta2,
+        const float eps,
+        const float bias_correction1,
+        const float bias_correction2_sqrt);
+
+}

--- a/fastgs/optimizer/include/adam_kernels.cuh
+++ b/fastgs/optimizer/include/adam_kernels.cuh
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cooperative_groups.h>
+namespace cg = cooperative_groups;
+
+namespace fast_gs::optimizer::kernels::adam {
+
+    // based on https://github.com/pytorch/pytorch/blob/9d32aa9789fc0ef0cad01a788157ecc2121db810/torch/csrc/api/src/optim/adam.cpp#L72-L142
+    __global__ void adam_step_cu(
+        float* param,
+        float* exp_avg,
+        float* exp_avg_sq,
+        const float* param_grad,
+        const int n_elements,
+        const float lr,
+        const float beta1,
+        const float beta2,
+        const float eps,
+        const float bias_correction1_rcp,
+        const float bias_correction2_sqrt_rcp)
+    {
+        auto idx = cg::this_grid().thread_rank();
+        if (idx >= n_elements) return;
+        const float grad = param_grad[idx];
+        const float moment1 = beta1 * exp_avg[idx] + (1.0f - beta1) * grad;
+        const float moment2 = beta2 * exp_avg_sq[idx] + (1.0f - beta2) * grad * grad;
+        const float denom = sqrtf(moment2) * bias_correction2_sqrt_rcp + eps;
+        const float step_size = lr * bias_correction1_rcp;
+        param[idx] -= step_size * moment1 / denom;
+        exp_avg[idx] = moment1;
+        exp_avg_sq[idx] = moment2;
+    }
+
+}

--- a/fastgs/optimizer/include/optimizer_config.h
+++ b/fastgs/optimizer/include/optimizer_config.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#define DEF inline constexpr
+
+namespace fast_gs::optimizer::config {
+    DEF bool debug = false;
+    // block size constants
+    DEF int block_size_adam_step = 256;
+}
+
+namespace config = fast_gs::optimizer::config;
+
+#undef DEF

--- a/fastgs/optimizer/src/adam.cu
+++ b/fastgs/optimizer/src/adam.cu
@@ -1,0 +1,34 @@
+#include "adam.h"
+#include "adam_kernels.cuh"
+#include "optimizer_config.h"
+#include "utils.h"
+
+void fast_gs::optimizer::adam_step(
+    float* param,
+    float* exp_avg,
+    float* exp_avg_sq,
+    const float* param_grad,
+    const int n_elements,
+    const float lr,
+    const float beta1,
+    const float beta2,
+    const float eps,
+    const float bias_correction1_rcp,
+    const float bias_correction2_sqrt_rcp)
+{
+    kernels::adam::adam_step_cu<<<div_round_up(n_elements, config::block_size_adam_step), config::block_size_adam_step>>>(
+        param,
+        exp_avg,
+        exp_avg_sq,
+        param_grad,
+        n_elements,
+        lr,
+        beta1,
+        beta2,
+        eps,
+        bias_correction1_rcp,
+        bias_correction2_sqrt_rcp
+    );
+    CHECK_CUDA(config::debug, "adam step")
+
+}

--- a/fastgs/optimizer/src/adam_api.cu
+++ b/fastgs/optimizer/src/adam_api.cu
@@ -1,0 +1,31 @@
+#include "adam_api.h"
+#include "adam.h"
+
+void fast_gs::optimizer::adam_step_wrapper(
+    torch::Tensor& param,
+    torch::Tensor& exp_avg,
+    torch::Tensor& exp_avg_sq,
+    const torch::Tensor& param_grad,
+    const float lr,
+    const float beta1,
+    const float beta2,
+    const float eps,
+    const float bias_correction1_rcp,
+    const float bias_correction2_sqrt_rcp)
+{
+    const int n_elements = param.numel();
+
+    adam_step(
+        param.data_ptr<float>(),
+        exp_avg.data_ptr<float>(),
+        exp_avg_sq.data_ptr<float>(),
+        param_grad.data_ptr<float>(),
+        n_elements,
+        lr,
+        beta1,
+        beta2,
+        eps,
+        bias_correction1_rcp,
+        bias_correction2_sqrt_rcp
+    );
+}

--- a/fastgs/rasterization/README.md
+++ b/fastgs/rasterization/README.md
@@ -1,0 +1,16 @@
+# Fast-GS Rasterizer
+
+This is an optimized CUDA implementation of the 3DGS rasterizer by Florian Hahlbohm.
+
+It includes a complete overhaul of the involved maths to skip unnecessary computations.
+Also, all activation functions of the Gaussians' parameters are fused into the respective kernels.
+
+Most importantly, this implementation combines ideas and tricks from the following works:
+
+- Underlying algorithm is based on "3D Gaussian Splatting for Real-Time Radiance Field Rendering" by Kerbl and Kopanas et al. 2023
+- Overall architecture is based on "Efficient Perspective-Correct 3D Gaussian Splatting Using Hybrid Transparency" by Hahlbohm et al. 2025
+- Culling and load balancing improvements are based on "StopThePop: Sorted Gaussian Splatting for View-Consistent Real-time Rendering" by Radl and Steiner et al. 2024
+- Efficient blending backward pass is based on "Taming 3DGS: High-Quality Radiance Fields with Limited Resources" by Mallick and Goel et al. 2024
+- Separate depth and tile sorting is based on "Splatshop: Efficiently Editing Large Gaussian Splat Models" by Schütz et al. 2025
+
+Please do not forget to credit these works if you use this implementation or parts of it in your own work.

--- a/fastgs/rasterization/include/backward.h
+++ b/fastgs/rasterization/include/backward.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "helper_math.h"
+#include <functional>
+
+namespace fast_gs::rasterization {
+
+    void backward(
+        const float* grad_image,
+        const float* image,
+        const float3* means,
+        const float3* scales_raw,
+        const float4* rotations_raw,
+        const float3* sh_coefficients_rest,
+        const float4* w2c,
+        const float3* cam_position,
+        const float3* bg_color,
+        char* per_primitive_buffers_blob,
+        char* per_tile_buffers_blob,
+        char* per_instance_buffers_blob,
+        char* per_bucket_buffers_blob,
+        float3* grad_means,
+        float3* grad_scales_raw,
+        float4* grad_rotations_raw,
+        float* grad_opacities_raw,
+        float3* grad_sh_coefficients_0,
+        float3* grad_sh_coefficients_rest,
+        float2* grad_mean2d_helper,
+        float* grad_conic_helper,
+        float* densification_info,
+        const int n_primitives,
+        const int n_visible_primitives,
+        const int n_instances,
+        const int n_buckets,
+        const int primitive_primitive_indices_selector,
+        const int instance_primitive_indices_selector,
+        const int active_sh_bases,
+        const int total_bases_sh_rest,
+        const int width,
+        const int height,
+        const float fx,
+        const float fy,
+        const float cx,
+        const float cy);
+
+}

--- a/fastgs/rasterization/include/buffer_utils.h
+++ b/fastgs/rasterization/include/buffer_utils.h
@@ -1,0 +1,154 @@
+#pragma once
+
+#include "rasterization_config.h"
+#include "helper_math.h"
+#include <cub/cub.cuh>
+#include <cstdint>
+
+namespace fast_gs::rasterization {
+
+    struct mat3x3 {
+        float m11, m12, m13;
+        float m21, m22, m23;
+        float m31, m32, m33;
+    };
+
+
+    struct __align__(8) mat3x3_triu {
+        float m11, m12, m13, m22, m23, m33;
+    };
+
+    template <typename T>
+    static void obtain(char*& blob, T*& ptr, std::size_t count, std::size_t alignment) {
+        std::size_t offset = reinterpret_cast<std::uintptr_t>(blob) + alignment - 1 & ~(alignment - 1);
+        ptr = reinterpret_cast<T*>(offset);
+        blob = reinterpret_cast<char*>(ptr + count);
+    }
+
+    template<typename T, typename... Args> 
+	size_t required(size_t P, Args... args){
+		char* size = nullptr;
+		T::from_blob(size, P, args...);
+		return ((size_t)size) + 128;
+	}
+
+    struct PerPrimitiveBuffers {
+        size_t cub_workspace_size;
+        char* cub_workspace;
+        cub::DoubleBuffer<uint> depth_keys;
+        cub::DoubleBuffer<uint> primitive_indices;
+        uint* n_touched_tiles;
+        uint* offset;
+        ushort4* screen_bounds;
+        float2* mean2d;
+        float4* conic_opacity;
+        float3* color;
+        uint* n_visible_primitives;
+        uint* n_instances;
+
+        static PerPrimitiveBuffers from_blob(char*& blob, size_t n_primitives) {
+            PerPrimitiveBuffers buffers;
+            uint* depth_keys_current;
+            obtain(blob, depth_keys_current, n_primitives, 128);
+            uint* depth_keys_alternate;
+            obtain(blob, depth_keys_alternate, n_primitives, 128);
+            buffers.depth_keys = cub::DoubleBuffer<uint>(depth_keys_current, depth_keys_alternate);
+            uint* primitive_indices_current;
+            obtain(blob, primitive_indices_current, n_primitives, 128);
+            uint* primitive_indices_alternate;
+            obtain(blob, primitive_indices_alternate, n_primitives, 128);
+            buffers.primitive_indices = cub::DoubleBuffer<uint>(primitive_indices_current, primitive_indices_alternate);
+            obtain(blob, buffers.n_touched_tiles, n_primitives, 128);
+            obtain(blob, buffers.offset, n_primitives, 128);
+            obtain(blob, buffers.screen_bounds, n_primitives, 128);
+            obtain(blob, buffers.mean2d, n_primitives, 128);
+            obtain(blob, buffers.conic_opacity, n_primitives, 128);
+            obtain(blob, buffers.color, n_primitives, 128);
+            cub::DeviceScan::ExclusiveSum(
+                nullptr, buffers.cub_workspace_size,
+                buffers.offset, buffers.offset,
+                n_primitives
+            );
+            size_t sorting_workspace_size;
+            cub::DeviceRadixSort::SortPairs(
+                nullptr, sorting_workspace_size,
+                buffers.depth_keys, buffers.primitive_indices,
+                n_primitives
+            );
+            buffers.cub_workspace_size = max(buffers.cub_workspace_size, sorting_workspace_size);
+            obtain(blob, buffers.cub_workspace, buffers.cub_workspace_size, 128);
+            obtain(blob, buffers.n_visible_primitives, 1, 128);
+            obtain(blob, buffers.n_instances, 1, 128);
+            return buffers;
+        }
+    };
+
+    struct PerInstanceBuffers {
+        size_t cub_workspace_size;
+        char* cub_workspace;
+        cub::DoubleBuffer<ushort> keys;
+        cub::DoubleBuffer<uint> primitive_indices;
+    
+        static PerInstanceBuffers from_blob(char*& blob, size_t n_instances) {
+            PerInstanceBuffers buffers;
+            ushort* keys_current;
+            obtain(blob, keys_current, n_instances, 128);
+            ushort* keys_alternate;
+            obtain(blob, keys_alternate, n_instances, 128);
+            buffers.keys = cub::DoubleBuffer<ushort>(keys_current, keys_alternate);
+            uint* primitive_indices_current;
+            obtain(blob, primitive_indices_current, n_instances, 128);
+            uint* primitive_indices_alternate;
+            obtain(blob, primitive_indices_alternate, n_instances, 128);
+            buffers.primitive_indices = cub::DoubleBuffer<uint>(primitive_indices_current, primitive_indices_alternate);
+            cub::DeviceRadixSort::SortPairs(
+                nullptr, buffers.cub_workspace_size,
+                buffers.keys, buffers.primitive_indices,
+                n_instances
+            );
+            obtain(blob, buffers.cub_workspace, buffers.cub_workspace_size, 128);
+            return buffers;
+        }
+    };
+
+    struct PerTileBuffers {
+        size_t cub_workspace_size;
+        char* cub_workspace;
+        uint2* instance_ranges;
+        uint* n_buckets;
+        uint* bucket_offsets;
+        uint* max_n_contributions;
+        uint* n_contributions;
+        float* final_transmittances;
+    
+        static PerTileBuffers from_blob(char*& blob, size_t n_tiles) {
+            PerTileBuffers buffers;
+            obtain(blob, buffers.instance_ranges, n_tiles, 128);
+            obtain(blob, buffers.n_buckets, n_tiles, 128);
+            obtain(blob, buffers.bucket_offsets, n_tiles, 128);
+            obtain(blob, buffers.max_n_contributions, n_tiles, 128);
+            obtain(blob, buffers.n_contributions, n_tiles * config::block_size_blend, 128);
+            obtain(blob, buffers.final_transmittances, n_tiles * config::block_size_blend, 128);
+            cub::DeviceScan::InclusiveSum(
+                nullptr, buffers.cub_workspace_size,
+                buffers.n_buckets, buffers.bucket_offsets,
+                n_tiles
+            );
+            obtain(blob, buffers.cub_workspace, buffers.cub_workspace_size, 128);
+            return buffers;
+        }
+    };
+
+    struct PerBucketBuffers {
+        uint* tile_index;
+        float4* color_transmittance;
+
+        static PerBucketBuffers from_blob(char*& blob, size_t n_buckets) {
+            PerBucketBuffers buffers;
+            obtain(blob, buffers.tile_index, n_buckets * config::block_size_blend, 128);
+            obtain(blob, buffers.color_transmittance, n_buckets * config::block_size_blend, 128);
+            return buffers;
+        }
+    };
+
+}

--- a/fastgs/rasterization/include/forward.h
+++ b/fastgs/rasterization/include/forward.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "helper_math.h"
+#include <functional>
+#include <tuple>
+
+namespace fast_gs::rasterization {
+
+    std::tuple<int, int, int, int, int> forward(
+        std::function<char* (size_t)> per_primitive_buffers_func,
+        std::function<char* (size_t)> per_tile_buffers_func,
+        std::function<char* (size_t)> per_instance_buffers_func,
+        std::function<char* (size_t)> per_bucket_buffers_func,
+        const float3* means,
+        const float3* scales_raw,
+        const float4* rotations_raw,
+        const float* opacities_raw,
+        const float3* sh_coefficients_0,
+        const float3* sh_coefficients_rest,
+        const float4* w2c,
+        const float3* cam_position,
+        const float3* bg_color,
+        float* image,
+        const int n_primitives,
+        const int active_sh_bases,
+        const int total_bases_sh_rest,
+        const int width,
+        const int height,
+        const float fx,
+        const float fy,
+        const float cx,
+        const float cy,
+        const float near,
+        const float far);
+
+}

--- a/fastgs/rasterization/include/kernel_utils.cuh
+++ b/fastgs/rasterization/include/kernel_utils.cuh
@@ -1,0 +1,247 @@
+#pragma once
+
+#include "rasterization_config.h"
+#include "helper_math.h"
+#include "utils.h"
+#include <cooperative_groups.h>
+namespace cg = cooperative_groups;
+
+namespace fast_gs::rasterization::kernels {
+
+    __device__ inline float3 convert_sh_to_color(
+        const float3* sh_coefficients_0,
+        const float3* sh_coefficients_rest,
+        const float3& position,
+        const float3& cam_position,
+        const uint primitive_idx,
+        const uint active_sh_bases,
+        const uint total_bases_sh_rest)
+    {
+        // computation adapted from https://github.com/NVlabs/tiny-cuda-nn/blob/212104156403bd87616c1a4f73a1c5f2c2e172a9/include/tiny-cuda-nn/common_device.h#L340
+        float3 result = 0.5f + 0.28209479177387814f * sh_coefficients_0[primitive_idx];
+        if (active_sh_bases > 1) {
+            const float3* coefficients_ptr = sh_coefficients_rest + primitive_idx * total_bases_sh_rest;
+            auto [x, y, z] = normalize(position - cam_position);
+            result = result + (-0.48860251190291987f * y) * coefficients_ptr[0]
+                            + (0.48860251190291987f * z) * coefficients_ptr[1]
+                            + (-0.48860251190291987f * x) * coefficients_ptr[2];
+            if (active_sh_bases > 4) {
+                const float xx = x * x, yy = y * y, zz = z * z;
+                const float xy = x * y, xz = x * z, yz = y * z;
+                result = result + (1.0925484305920792f * xy) * coefficients_ptr[3]
+                                + (-1.0925484305920792f * yz) * coefficients_ptr[4]
+                                + (0.94617469575755997f * zz - 0.31539156525251999f) * coefficients_ptr[5]
+                                + (-1.0925484305920792f * xz) * coefficients_ptr[6]
+                                + (0.54627421529603959f * xx - 0.54627421529603959f * yy) * coefficients_ptr[7];
+                if (active_sh_bases > 9) {
+                    result = result + (0.59004358992664352f * y * (-3.0f * xx + yy)) * coefficients_ptr[8]
+                                    + (2.8906114426405538f * xy * z) * coefficients_ptr[9]
+                                    + (0.45704579946446572f * y * (1.0f - 5.0f * zz)) * coefficients_ptr[10]
+                                    + (0.3731763325901154f * z * (5.0f * zz - 3.0f)) * coefficients_ptr[11]
+                                    + (0.45704579946446572f * x * (1.0f - 5.0f * zz)) * coefficients_ptr[12]
+                                    + (1.4453057213202769f * z * (xx - yy)) * coefficients_ptr[13]
+                                    + (0.59004358992664352f * x * (-xx + 3.0f * yy)) * coefficients_ptr[14];
+                }
+            }
+        }
+        return result;
+    }
+
+    __device__ inline float3 convert_sh_to_color_backward(
+        const float3* sh_coefficients_rest,
+        float3* grad_sh_coefficients_0,
+        float3* grad_sh_coefficients_rest,
+        const float3& position,
+        const float3& cam_position,
+        const uint primitive_idx,
+        const uint active_sh_bases,
+        const uint total_bases_sh_rest)
+    {
+        // computation adapted from https://github.com/NVlabs/tiny-cuda-nn/blob/212104156403bd87616c1a4f73a1c5f2c2e172a9/include/tiny-cuda-nn/common_device.h#L340
+        const int coefficients_base_idx = primitive_idx * total_bases_sh_rest;
+        const float3* coefficients_ptr = sh_coefficients_rest + coefficients_base_idx;
+        float3* grad_coefficients_ptr = grad_sh_coefficients_rest + coefficients_base_idx;
+        const float3 grad_color = grad_sh_coefficients_0[primitive_idx];
+        grad_sh_coefficients_0[primitive_idx] = 0.28209479177387814f * grad_color;
+        float3 dcolor_dposition = make_float3(0.0f);
+        if (active_sh_bases > 1) {
+            auto [x_raw, y_raw, z_raw] = position - cam_position;
+            auto [x, y, z] = normalize(make_float3(x_raw, y_raw, z_raw));
+            grad_coefficients_ptr[0] = (-0.48860251190291987f * y) * grad_color;
+            grad_coefficients_ptr[1] = (0.48860251190291987f * z) * grad_color;
+            grad_coefficients_ptr[2] = (-0.48860251190291987f * x) * grad_color;
+            float3 grad_direction_x = -0.48860251190291987f * coefficients_ptr[2];
+            float3 grad_direction_y = -0.48860251190291987f * coefficients_ptr[0];
+            float3 grad_direction_z = 0.48860251190291987f * coefficients_ptr[1];
+            if (active_sh_bases > 4) {
+                const float xx = x * x, yy = y * y, zz = z * z;
+                const float xy = x * y, xz = x * z, yz = y * z;
+                grad_coefficients_ptr[3] = (1.0925484305920792f * xy) * grad_color;
+                grad_coefficients_ptr[4] = (-1.0925484305920792f * yz) * grad_color;
+                grad_coefficients_ptr[5] = (0.94617469575755997f * zz - 0.31539156525251999f) * grad_color;
+                grad_coefficients_ptr[6] = (-1.0925484305920792f * xz) * grad_color;
+                grad_coefficients_ptr[7] = (0.54627421529603959f * xx - 0.54627421529603959f * yy) * grad_color;
+                grad_direction_x = grad_direction_x + (1.0925484305920792f * y) * coefficients_ptr[3]
+                                                    + (-1.0925484305920792f * z) * coefficients_ptr[6]
+                                                    + (1.0925484305920792 * x) * coefficients_ptr[7];
+                grad_direction_y = grad_direction_y + (1.0925484305920792f * x) * coefficients_ptr[3]
+                                                    + (-1.0925484305920792f * z) * coefficients_ptr[4]
+                                                    + (-1.0925484305920792 * y) * coefficients_ptr[7];
+                grad_direction_z = grad_direction_z + (-1.0925484305920792f * y) * coefficients_ptr[4]
+                                                    + (1.8923493915151202 * z) * coefficients_ptr[5]
+                                                    + (-1.0925484305920792f * x) * coefficients_ptr[6];
+                if (active_sh_bases > 9) {
+                    grad_coefficients_ptr[8] = (0.59004358992664352f * y * (-3.0f * xx + yy)) * grad_color;
+                    grad_coefficients_ptr[9] = (2.8906114426405538f * xy * z) * grad_color;
+                    grad_coefficients_ptr[10] = (0.45704579946446572f * y * (1.0f - 5.0f * zz)) * grad_color;
+                    grad_coefficients_ptr[11] = (0.3731763325901154f * z * (5.0f * zz - 3.0f)) * grad_color;
+                    grad_coefficients_ptr[12] = (0.45704579946446572f * x * (1.0f - 5.0f * zz)) * grad_color;
+                    grad_coefficients_ptr[13] = (1.4453057213202769f * z * (xx - yy)) * grad_color;
+                    grad_coefficients_ptr[14] = (0.59004358992664352f * x * (-xx + 3.0f * yy)) * grad_color;
+                    grad_direction_x = grad_direction_x + (-3.5402615395598609f * xy) * coefficients_ptr[8]
+                                                        + (2.8906114426405538f * yz) * coefficients_ptr[9]
+                                                        + (0.45704579946446572f - 2.2852289973223288f * zz) * coefficients_ptr[12]
+                                                        + (2.8906114426405538f * xz) * coefficients_ptr[13]
+                                                        + (-1.7701307697799304f * xx + 1.7701307697799304f * yy) * coefficients_ptr[14];
+                    grad_direction_y = grad_direction_y + (-1.7701307697799304f * xx + 1.7701307697799304f * yy) * coefficients_ptr[8]
+                                                        + (2.8906114426405538f * xz) * coefficients_ptr[9]
+                                                        + (0.45704579946446572f - 2.2852289973223288f * zz) * coefficients_ptr[10]
+                                                        + (-2.8906114426405538f * yz) * coefficients_ptr[13]
+                                                        + (3.5402615395598609f * xy) * coefficients_ptr[14];
+                    grad_direction_z = grad_direction_z + (2.8906114426405538f * xy) * coefficients_ptr[9]
+                                                        + (-4.5704579946446566f * yz) * coefficients_ptr[10]
+                                                        + (5.597644988851731f * zz - 1.1195289977703462f) * coefficients_ptr[11]
+                                                        + (-4.5704579946446566f * xz) * coefficients_ptr[12]
+                                                        + (1.4453057213202769f * xx - 1.4453057213202769f * yy) * coefficients_ptr[13];
+                }
+            }
+
+            const float3 grad_direction = make_float3(
+                dot(grad_direction_x, grad_color),
+                dot(grad_direction_y, grad_color),
+                dot(grad_direction_z, grad_color)
+            );
+            const float xx_raw = x_raw * x_raw, yy_raw = y_raw * y_raw, zz_raw = z_raw * z_raw;
+            const float xy_raw = x_raw * y_raw, xz_raw = x_raw * z_raw, yz_raw = y_raw * z_raw;
+            const float norm_sq = xx_raw + yy_raw + zz_raw;
+            dcolor_dposition = make_float3(
+                (yy_raw + zz_raw) * grad_direction.x - xy_raw * grad_direction.y - xz_raw * grad_direction.z,
+                -xy_raw * grad_direction.x + (xx_raw + zz_raw) * grad_direction.y - yz_raw * grad_direction.z,
+                -xz_raw * grad_direction.x - yz_raw * grad_direction.y + (xx_raw + yy_raw) * grad_direction.z
+            ) * rsqrtf(norm_sq * norm_sq * norm_sq);
+        }
+        return dcolor_dposition;
+    }
+
+    // based on https://github.com/r4dl/StopThePop-Rasterization/blob/d8cad09919ff49b11be3d693d1e71fa792f559bb/cuda_rasterizer/stopthepop/stopthepop_common.cuh#L131
+    __device__ inline bool will_primitive_contribute(
+        const float2& mean,
+        const float3& conic,
+        const uint tile_x,
+        const uint tile_y,
+        const float power_threshold)
+    {
+        const float2 rect_min = make_float2(static_cast<float>(tile_x * config::tile_width), static_cast<float>(tile_y * config::tile_height));
+        const float2 rect_max = make_float2(static_cast<float>((tile_x + 1) * config::tile_width - 1), static_cast<float>((tile_y + 1) * config::tile_height - 1));
+
+        const float x_min_diff = rect_min.x - mean.x;
+        const float x_left = static_cast<float>(x_min_diff > 0.0f);
+        const float not_in_x_range = x_left + static_cast<float>(mean.x > rect_max.x);
+        const float y_min_diff = rect_min.y - mean.y;
+        const float y_above = static_cast<float>(y_min_diff > 0.0f);
+        const float not_in_y_range = y_above + static_cast<float>(mean.y > rect_max.y);
+
+        // let's hope the compiler optimizes this properly
+        if (not_in_y_range + not_in_x_range == 0.0f) return true;
+        else {
+            const float2 closest_corner = make_float2(
+                lerp(rect_max.x, rect_min.x, x_left),
+                lerp(rect_max.y, rect_min.y, y_above)
+            );
+            const float2 diff = mean - closest_corner;
+
+            const float2 d = make_float2(
+                copysignf(static_cast<float>(config::tile_width - 1), x_min_diff),
+                copysignf(static_cast<float>(config::tile_height - 1), y_min_diff)
+            );
+            const float2 t = make_float2(
+                not_in_y_range * __saturatef((d.x * conic.x * diff.x + d.x * conic.y * diff.y) / (d.x * conic.x * d.x)),
+                not_in_x_range * __saturatef((d.y * conic.y * diff.x + d.y * conic.z * diff.y) / (d.y * conic.z * d.y))
+            );
+            const float2 max_contribution_point = closest_corner + t * d;
+            const float2 delta = mean - max_contribution_point;
+            const float max_power_in_tile = 0.5f * (conic.x * delta.x * delta.x + conic.z * delta.y * delta.y) + conic.y * delta.x * delta.y;
+            return max_power_in_tile <= power_threshold;
+        }
+    }
+
+    // based on https://github.com/r4dl/StopThePop-Rasterization/blob/d8cad09919ff49b11be3d693d1e71fa792f559bb/cuda_rasterizer/stopthepop/stopthepop_common.cuh#L177
+    __device__ inline uint compute_exact_n_touched_tiles(
+        const float2& mean2d,
+        const float3& conic,
+        const uint4& screen_bounds,
+        const float power_threshold,
+        const uint tile_count,
+        const bool active)
+    {
+        const float2 mean2d_shifted = mean2d - 0.5f;
+
+        uint n_touched_tiles = 0;
+        if (active) {
+            const uint screen_bounds_width = screen_bounds.y - screen_bounds.x;
+            for (uint instance_idx = 0; instance_idx < tile_count && instance_idx < config::n_sequential_threshold; instance_idx++) {
+                const uint tile_y = screen_bounds.z + (instance_idx / screen_bounds_width);
+                const uint tile_x = screen_bounds.x + (instance_idx % screen_bounds_width);
+                if (will_primitive_contribute(mean2d_shifted, conic, tile_x, tile_y, power_threshold)) n_touched_tiles++;
+            }
+        }
+
+        const uint lane_idx = cg::this_thread_block().thread_rank() % 32u;
+        const uint warp_idx = cg::this_thread_block().thread_rank() / 32u;
+
+        const int compute_cooperatively = active && tile_count > config::n_sequential_threshold;
+        const uint remaining_threads = __ballot_sync(0xffffffffu, compute_cooperatively);
+        if (remaining_threads == 0) return n_touched_tiles;
+
+        const uint n_remaining_threads = __popc(remaining_threads);
+        for (int n = 0; n < n_remaining_threads && n < 32; n++) {
+            const uint current_lane = __fns(remaining_threads, 0, n + 1); // find lane index of next remaining thread
+
+            const uint4 screen_bounds_coop = make_uint4(
+                __shfl_sync(0xffffffffu, screen_bounds.x, current_lane),
+                __shfl_sync(0xffffffffu, screen_bounds.y, current_lane),
+                __shfl_sync(0xffffffffu, screen_bounds.z, current_lane),
+                __shfl_sync(0xffffffffu, screen_bounds.w, current_lane)
+            );
+            const uint screen_bounds_width_coop = screen_bounds_coop.y - screen_bounds_coop.x;
+            const uint tile_count_coop = (screen_bounds_coop.w - screen_bounds_coop.z) * screen_bounds_width_coop;
+
+            const float2 mean2d_shifted_coop = make_float2(
+                __shfl_sync(0xffffffffu, mean2d_shifted.x, current_lane),
+                __shfl_sync(0xffffffffu, mean2d_shifted.y, current_lane)
+            );
+            const float3 conic_coop = make_float3(
+                __shfl_sync(0xffffffffu, conic.x, current_lane),
+                __shfl_sync(0xffffffffu, conic.y, current_lane),
+                __shfl_sync(0xffffffffu, conic.z, current_lane)
+            );
+            const float power_threshold_coop = __shfl_sync(0xffffffffu, power_threshold, current_lane);
+
+            const uint remaining_tile_count = tile_count_coop - config::n_sequential_threshold;
+            const int n_iterations = div_round_up(remaining_tile_count, 32u);
+            for (int i = 0; i < n_iterations; i++) {
+                const int instance_idx = i * 32 + lane_idx + config::n_sequential_threshold;
+                const int active_current = instance_idx < tile_count_coop;
+                const uint tile_y = screen_bounds_coop.z + (instance_idx / screen_bounds_width_coop);
+                const uint tile_x = screen_bounds_coop.x + (instance_idx % screen_bounds_width_coop);
+                const uint contributes = active_current && will_primitive_contribute(mean2d_shifted_coop, conic_coop, tile_x, tile_y, power_threshold_coop);
+                const uint contributes_ballot = __ballot_sync(0xffffffffu, contributes);
+                const uint n_contributes = __popc(contributes_ballot);
+                n_touched_tiles += (current_lane == lane_idx) * n_contributes;
+            }
+        }
+
+        return n_touched_tiles;
+    }
+
+}

--- a/fastgs/rasterization/include/kernels_backward.cuh
+++ b/fastgs/rasterization/include/kernels_backward.cuh
@@ -1,0 +1,453 @@
+#pragma once
+
+#include "rasterization_config.h"
+#include "kernel_utils.cuh"
+#include "buffer_utils.h"
+#include "helper_math.h"
+#include "utils.h"
+#include <cstdint>
+#include <cooperative_groups.h>
+namespace cg = cooperative_groups;
+
+namespace fast_gs::rasterization::kernels::backward {
+
+    __global__ void preprocess_backward_cu(
+        const float3* means,
+        const float3* raw_scales,
+        const float4* raw_rotations,
+        const float3* sh_coefficients_rest,
+        const float4* w2c,
+        const float3* cam_position,
+        const uint* primitive_n_touched_tiles,
+        const float2* grad_mean2d,
+        const float* grad_conic,
+        float3* grad_means,
+        float3* grad_raw_scales,
+        float4* grad_raw_rotations,
+        float3* grad_sh_coefficients_0,
+        float3* grad_sh_coefficients_rest,
+        float* densification_info,
+        const uint n_primitives,
+        const uint active_sh_bases,
+        const uint total_bases_sh_rest,
+        const float w,
+        const float h,
+        const float fx,
+        const float fy,
+        const float cx,
+        const float cy)
+    {
+        auto primitive_idx = cg::this_grid().thread_rank();
+        if (primitive_idx >= n_primitives || primitive_n_touched_tiles[primitive_idx] == 0) return;
+
+        // load 3d mean
+        const float3 mean3d = means[primitive_idx];
+
+        // sh evaluation backward
+        const float3 dL_dmean3d_from_color = convert_sh_to_color_backward(
+            sh_coefficients_rest, grad_sh_coefficients_0, grad_sh_coefficients_rest,
+            mean3d, cam_position[0],
+            primitive_idx, active_sh_bases, total_bases_sh_rest
+        );
+
+        const float4 w2c_r3 = w2c[2];
+        const float depth = w2c_r3.x * mean3d.x + w2c_r3.y * mean3d.y + w2c_r3.z * mean3d.z + w2c_r3.w;
+        const float4 w2c_r1 = w2c[0];
+        const float x = (w2c_r1.x * mean3d.x + w2c_r1.y * mean3d.y + w2c_r1.z * mean3d.z + w2c_r1.w) / depth;
+        const float4 w2c_r2 = w2c[1];
+        const float y = (w2c_r2.x * mean3d.x + w2c_r2.y * mean3d.y + w2c_r2.z * mean3d.z + w2c_r2.w) / depth;
+
+        // compute 3d covariance from raw scale and rotation
+        const float3 raw_scale = raw_scales[primitive_idx];
+        const float3 variance = make_float3(expf(2.0f * raw_scale.x), expf(2.0f * raw_scale.y), expf(2.0f * raw_scale.z));
+        auto [qr, qx, qy, qz] = raw_rotations[primitive_idx];
+        const float qrr_raw = qr * qr, qxx_raw = qx * qx, qyy_raw = qy * qy, qzz_raw = qz * qz;
+        const float q_norm_sq = qrr_raw + qxx_raw + qyy_raw + qzz_raw;
+        const float qxx = 2.0f * qxx_raw / q_norm_sq, qyy = 2.0f * qyy_raw / q_norm_sq, qzz = 2.0f * qzz_raw / q_norm_sq;
+        const float qxy = 2.0f * qx * qy / q_norm_sq, qxz = 2.0f * qx * qz / q_norm_sq, qyz = 2.0f * qy * qz / q_norm_sq;
+        const float qrx = 2.0f * qr * qx / q_norm_sq, qry = 2.0f * qr * qy / q_norm_sq, qrz = 2.0f * qr * qz / q_norm_sq;
+        const mat3x3 rotation = {
+            1.0f - (qyy + qzz), qxy - qrz, qry + qxz,
+            qrz + qxy, 1.0f - (qxx + qzz), qyz - qrx,
+            qxz - qry, qrx + qyz, 1.0f - (qxx + qyy)
+        };
+        const mat3x3 rotation_scaled = {
+            rotation.m11 * variance.x, rotation.m12 * variance.y, rotation.m13 * variance.z,
+            rotation.m21 * variance.x, rotation.m22 * variance.y, rotation.m23 * variance.z,
+            rotation.m31 * variance.x, rotation.m32 * variance.y, rotation.m33 * variance.z
+        };
+        const mat3x3_triu cov3d {
+            rotation_scaled.m11 * rotation.m11 + rotation_scaled.m12 * rotation.m12 + rotation_scaled.m13 * rotation.m13,
+            rotation_scaled.m11 * rotation.m21 + rotation_scaled.m12 * rotation.m22 + rotation_scaled.m13 * rotation.m23,
+            rotation_scaled.m11 * rotation.m31 + rotation_scaled.m12 * rotation.m32 + rotation_scaled.m13 * rotation.m33,
+            rotation_scaled.m21 * rotation.m21 + rotation_scaled.m22 * rotation.m22 + rotation_scaled.m23 * rotation.m23,
+            rotation_scaled.m21 * rotation.m31 + rotation_scaled.m22 * rotation.m32 + rotation_scaled.m23 * rotation.m33,
+            rotation_scaled.m31 * rotation.m31 + rotation_scaled.m32 * rotation.m32 + rotation_scaled.m33 * rotation.m33,
+        };
+
+        // ewa splatting gradient helpers
+        const float clip_left = (-0.15f * w - cx) / fx;
+        const float clip_right = (1.15f * w - cx) / fx;
+        const float clip_top = (-0.15f * h - cy) / fy;
+        const float clip_bottom = (1.15f * h - cy) / fy;
+        const float tx = clamp(x, clip_left, clip_right);
+        const float ty = clamp(y, clip_top, clip_bottom);
+        const float j11 = fx / depth;
+        const float j13 = -j11 * tx;
+        const float j22 = fy / depth;
+        const float j23 = -j22 * ty;
+        const float3 jw_r1 = make_float3(
+            j11 * w2c_r1.x + j13 * w2c_r3.x,
+            j11 * w2c_r1.y + j13 * w2c_r3.y,
+            j11 * w2c_r1.z + j13 * w2c_r3.z
+        );
+        const float3 jw_r2 = make_float3(
+            j22 * w2c_r2.x + j23 * w2c_r3.x,
+            j22 * w2c_r2.y + j23 * w2c_r3.y,
+            j22 * w2c_r2.z + j23 * w2c_r3.z
+        );
+        const float3 jwc_r1 = make_float3(
+            jw_r1.x * cov3d.m11 + jw_r1.y * cov3d.m12 + jw_r1.z * cov3d.m13,
+            jw_r1.x * cov3d.m12 + jw_r1.y * cov3d.m22 + jw_r1.z * cov3d.m23,
+            jw_r1.x * cov3d.m13 + jw_r1.y * cov3d.m23 + jw_r1.z * cov3d.m33
+        );
+        const float3 jwc_r2 = make_float3(
+            jw_r2.x * cov3d.m11 + jw_r2.y * cov3d.m12 + jw_r2.z * cov3d.m13,
+            jw_r2.x * cov3d.m12 + jw_r2.y * cov3d.m22 + jw_r2.z * cov3d.m23,
+            jw_r2.x * cov3d.m13 + jw_r2.y * cov3d.m23 + jw_r2.z * cov3d.m33
+        );
+
+        // 2d covariance gradient
+        const float a = dot(jwc_r1, jw_r1) + config::dilation, b = dot(jwc_r1, jw_r2), c = dot(jwc_r2, jw_r2) + config::dilation;
+        const float aa = a * a, bb = b * b, cc = c * c;
+        const float ac = a * c, ab = a * b, bc = b * c;
+        const float determinant = ac - bb;
+        const float determinant_rcp = 1.0f / determinant;
+        const float determinant_rcp_sq = determinant_rcp * determinant_rcp;
+        const float3 dL_dconic = make_float3(
+            grad_conic[primitive_idx],
+            grad_conic[n_primitives + primitive_idx],
+            grad_conic[2 * n_primitives + primitive_idx]
+        );
+        const float3 dL_dcov2d = determinant_rcp_sq * make_float3(
+            2.0f * bc * dL_dconic.y - cc * dL_dconic.x - bb * dL_dconic.z,
+            bc * dL_dconic.x - (ac + bb) * dL_dconic.y + ab * dL_dconic.z,
+            2.0f * ab * dL_dconic.y - bb * dL_dconic.x - aa * dL_dconic.z
+        );
+
+        // 3d covariance gradient
+        const mat3x3_triu dL_dcov3d = {
+            (jw_r1.x * jw_r1.x) * dL_dcov2d.x + 2.0f * (jw_r1.x * jw_r2.x) * dL_dcov2d.y + (jw_r2.x * jw_r2.x) * dL_dcov2d.z,
+            (jw_r1.x * jw_r1.y) * dL_dcov2d.x + (jw_r1.x * jw_r2.y + jw_r1.y * jw_r2.x) * dL_dcov2d.y + (jw_r2.x * jw_r2.y) * dL_dcov2d.z,
+            (jw_r1.x * jw_r1.z) * dL_dcov2d.x + (jw_r1.x * jw_r2.z + jw_r1.z * jw_r2.x) * dL_dcov2d.y + (jw_r2.x * jw_r2.z) * dL_dcov2d.z,
+            (jw_r1.y * jw_r1.y) * dL_dcov2d.x + 2.0f * (jw_r1.y * jw_r2.y) * dL_dcov2d.y + (jw_r2.y * jw_r2.y) * dL_dcov2d.z,
+            (jw_r1.y * jw_r1.z) * dL_dcov2d.x + (jw_r1.y * jw_r2.z + jw_r1.z * jw_r2.y) * dL_dcov2d.y + (jw_r2.y * jw_r2.z) * dL_dcov2d.z,
+            (jw_r1.z * jw_r1.z) * dL_dcov2d.x + 2.0f * (jw_r1.z * jw_r2.z) * dL_dcov2d.y + (jw_r2.z * jw_r2.z) * dL_dcov2d.z,
+        };
+
+        // gradient of J * W
+        const float3 dL_djw_r1 = 2.0f * make_float3(
+            jwc_r1.x * dL_dcov2d.x + jwc_r2.x * dL_dcov2d.y,
+            jwc_r1.y * dL_dcov2d.x + jwc_r2.y * dL_dcov2d.y,
+            jwc_r1.z * dL_dcov2d.x + jwc_r2.z * dL_dcov2d.y
+        );
+        const float3 dL_djw_r2 = 2.0f * make_float3(
+            jwc_r1.x * dL_dcov2d.y + jwc_r2.x * dL_dcov2d.z,
+            jwc_r1.y * dL_dcov2d.y + jwc_r2.y * dL_dcov2d.z,
+            jwc_r1.z * dL_dcov2d.y + jwc_r2.z * dL_dcov2d.z
+        );
+
+        // gradient of non-zero entries in J
+        const float dL_dj11 = w2c_r1.x * dL_djw_r1.x + w2c_r1.y * dL_djw_r1.y + w2c_r1.z * dL_djw_r1.z;
+        const float dL_dj22 = w2c_r2.x * dL_djw_r2.x + w2c_r2.y * dL_djw_r2.y + w2c_r2.z * dL_djw_r2.z;
+        const float dL_dj13 = w2c_r3.x * dL_djw_r1.x + w2c_r3.y * dL_djw_r1.y + w2c_r3.z * dL_djw_r1.z;
+        const float dL_dj23 = w2c_r3.x * dL_djw_r2.x + w2c_r3.y * dL_djw_r2.y + w2c_r3.z * dL_djw_r2.z;
+
+        // mean3d camera space gradient from J and mean2d
+        // TODO: original 3dgs accounts for clamping of tx/ty here, but it seems that this is not necessary
+        float djwr1_dz_helper = dL_dj11 - 2.0f * tx * dL_dj13;
+        float djwr2_dz_helper = dL_dj22 - 2.0f * ty * dL_dj23;
+        const float2 dL_dmean2d = grad_mean2d[primitive_idx];
+        const float3 dL_dmean3d_cam = make_float3(
+            j11 * (dL_dmean2d.x - dL_dj13 / depth),
+            j22 * (dL_dmean2d.y - dL_dj23 / depth),
+            -j11 * (x * dL_dmean2d.x + djwr1_dz_helper / depth) - j22 * (y * dL_dmean2d.y + djwr2_dz_helper / depth)
+        );
+
+        // 3d mean gradient from splatting
+        const float3 dL_dmean3d_from_splatting = make_float3(
+            w2c_r1.x * dL_dmean3d_cam.x + w2c_r2.x * dL_dmean3d_cam.y + w2c_r3.x * dL_dmean3d_cam.z,
+            w2c_r1.y * dL_dmean3d_cam.x + w2c_r2.y * dL_dmean3d_cam.y + w2c_r3.y * dL_dmean3d_cam.z,
+            w2c_r1.z * dL_dmean3d_cam.x + w2c_r2.z * dL_dmean3d_cam.y + w2c_r3.z * dL_dmean3d_cam.z
+        );
+
+        // write total 3d mean gradient
+        const float3 dL_dmean3d = dL_dmean3d_from_splatting + dL_dmean3d_from_color;
+        grad_means[primitive_idx] = dL_dmean3d;
+
+        // raw scale gradient
+        const float dL_dvariance_x = rotation.m11 * rotation.m11 * dL_dcov3d.m11 + rotation.m21 * rotation.m21 * dL_dcov3d.m22 + rotation.m31 * rotation.m31 * dL_dcov3d.m33 +
+                             2.0f * (rotation.m11 * rotation.m21 * dL_dcov3d.m12 + rotation.m11 * rotation.m31 * dL_dcov3d.m13 + rotation.m21 * rotation.m31 * dL_dcov3d.m23);
+        const float dL_dvariance_y = rotation.m12 * rotation.m12 * dL_dcov3d.m11 + rotation.m22 * rotation.m22 * dL_dcov3d.m22 + rotation.m32 * rotation.m32 * dL_dcov3d.m33 +
+                             2.0f * (rotation.m12 * rotation.m22 * dL_dcov3d.m12 + rotation.m12 * rotation.m32 * dL_dcov3d.m13 + rotation.m22 * rotation.m32 * dL_dcov3d.m23);
+        const float dL_dvariance_z = rotation.m13 * rotation.m13 * dL_dcov3d.m11 + rotation.m23 * rotation.m23 * dL_dcov3d.m22 + rotation.m33 * rotation.m33 * dL_dcov3d.m33 +
+                             2.0f * (rotation.m13 * rotation.m23 * dL_dcov3d.m12 + rotation.m13 * rotation.m33 * dL_dcov3d.m13 + rotation.m23 * rotation.m33 * dL_dcov3d.m23);
+        const float3 dL_draw_scale = make_float3(
+            2.0f * variance.x * dL_dvariance_x,
+            2.0f * variance.y * dL_dvariance_y,
+            2.0f * variance.z * dL_dvariance_z
+        );
+        grad_raw_scales[primitive_idx] = dL_draw_scale;
+
+        // raw rotation gradient
+        const mat3x3 dL_drotation = {
+            2.0f * (rotation_scaled.m11 * dL_dcov3d.m11 + rotation_scaled.m21 * dL_dcov3d.m12 + rotation_scaled.m31 * dL_dcov3d.m13),
+            2.0f * (rotation_scaled.m12 * dL_dcov3d.m11 + rotation_scaled.m22 * dL_dcov3d.m12 + rotation_scaled.m32 * dL_dcov3d.m13),
+            2.0f * (rotation_scaled.m13 * dL_dcov3d.m11 + rotation_scaled.m23 * dL_dcov3d.m12 + rotation_scaled.m33 * dL_dcov3d.m13),
+            2.0f * (rotation_scaled.m11 * dL_dcov3d.m12 + rotation_scaled.m21 * dL_dcov3d.m22 + rotation_scaled.m31 * dL_dcov3d.m23),
+            2.0f * (rotation_scaled.m12 * dL_dcov3d.m12 + rotation_scaled.m22 * dL_dcov3d.m22 + rotation_scaled.m32 * dL_dcov3d.m23),
+            2.0f * (rotation_scaled.m13 * dL_dcov3d.m12 + rotation_scaled.m23 * dL_dcov3d.m22 + rotation_scaled.m33 * dL_dcov3d.m23),
+            2.0f * (rotation_scaled.m11 * dL_dcov3d.m13 + rotation_scaled.m21 * dL_dcov3d.m23 + rotation_scaled.m31 * dL_dcov3d.m33),
+            2.0f * (rotation_scaled.m12 * dL_dcov3d.m13 + rotation_scaled.m22 * dL_dcov3d.m23 + rotation_scaled.m32 * dL_dcov3d.m33),
+            2.0f * (rotation_scaled.m13 * dL_dcov3d.m13 + rotation_scaled.m23 * dL_dcov3d.m23 + rotation_scaled.m33 * dL_dcov3d.m33)
+        };
+        const float dL_dqxx = -dL_drotation.m22 - dL_drotation.m33;
+        const float dL_dqyy = -dL_drotation.m11 - dL_drotation.m33;
+        const float dL_dqzz = -dL_drotation.m11 - dL_drotation.m22;
+        const float dL_dqxy = dL_drotation.m12 + dL_drotation.m21;
+        const float dL_dqxz = dL_drotation.m13 + dL_drotation.m31;
+        const float dL_dqyz = dL_drotation.m23 + dL_drotation.m32;
+        const float dL_dqrx = dL_drotation.m32 - dL_drotation.m23;
+        const float dL_dqry = dL_drotation.m13 - dL_drotation.m31;
+        const float dL_dqrz = dL_drotation.m21 - dL_drotation.m12;
+        const float dL_dq_norm_helper = qxx * dL_dqxx + qyy * dL_dqyy + qzz * dL_dqzz + qxy * dL_dqxy + qxz * dL_dqxz + qyz * dL_dqyz + qrx * dL_dqrx + qry * dL_dqry + qrz * dL_dqrz;
+        const float4 dL_draw_rotation = 2.0f * make_float4(
+            qx * dL_dqrx + qy * dL_dqry + qz * dL_dqrz - qr * dL_dq_norm_helper,
+            2.0f * qx * dL_dqxx + qy * dL_dqxy + qz * dL_dqxz + qr * dL_dqrx - qx * dL_dq_norm_helper,
+            2.0f * qy * dL_dqyy + qx * dL_dqxy + qz * dL_dqyz + qr * dL_dqry - qy * dL_dq_norm_helper,
+            2.0f * qz * dL_dqzz + qx * dL_dqxz + qy * dL_dqyz + qr * dL_dqrz - qz * dL_dq_norm_helper
+        ) / q_norm_sq;
+        grad_raw_rotations[primitive_idx] = dL_draw_rotation;
+
+        // TODO: only needed for adaptive density control from the original 3dgs
+        if (densification_info != nullptr) {
+            densification_info[primitive_idx] += 1.0f;
+            densification_info[n_primitives + primitive_idx] += length(dL_dmean2d * make_float2(0.5f * w, 0.5f * h));
+        }
+
+    }
+
+    // based on https://github.com/humansensinglab/taming-3dgs/blob/fd0f7d9edfe135eb4eefd3be82ee56dada7f2a16/submodules/diff-gaussian-rasterization/cuda_rasterizer/backward.cu#L404
+    __global__ void blend_backward_cu(
+        const uint2* tile_instance_ranges,
+        const uint* tile_bucket_offsets,
+        const uint* instance_primitive_indices,
+        const float2* primitive_mean2d,
+        const float4* primitive_conic_opacity,
+        const float3* primitive_color,
+        const float3* bg_color,
+        const float* grad_image,
+        const float* image,
+        const float* tile_final_transmittances,
+        const uint* tile_max_n_contributions,
+        const uint* tile_n_contributions,
+        const uint* bucket_tile_index,
+        const float4* bucket_color_transmittance,
+        float2* grad_mean2d,
+        float* grad_conic,
+        float* grad_raw_opacity,
+        float3* grad_color,
+        const uint n_buckets,
+        const uint n_primitives,
+        const uint width,
+        const uint height,
+        const uint grid_width)
+    {
+        auto block = cg::this_thread_block();
+        const uint bucket_idx = block.group_index().x;
+        if (bucket_idx >= n_buckets) return;
+        auto warp = cg::tiled_partition<32>(block);
+        const uint lane_idx = warp.thread_rank();
+
+        const uint tile_idx = bucket_tile_index[bucket_idx];
+        const uint2 tile_instance_range = tile_instance_ranges[tile_idx];
+        const int tile_n_primitives = tile_instance_range.y - tile_instance_range.x;
+        const uint tile_first_bucket_offset = tile_idx == 0 ? 0 : tile_bucket_offsets[tile_idx - 1];
+        const int tile_bucket_idx = bucket_idx - tile_first_bucket_offset;
+        if (tile_bucket_idx * 32 >= tile_max_n_contributions[tile_idx]) return;
+
+        const int tile_primitive_idx = tile_bucket_idx * 32 + lane_idx;
+        const int instance_idx = tile_instance_range.x + tile_primitive_idx;
+        const bool valid_primitive = tile_primitive_idx < tile_n_primitives;
+
+        // load gaussian data
+        uint primitive_idx = 0;
+        float2 mean2d = {0.0f, 0.0f};
+        float3 conic = {0.0f, 0.0f, 0.0f};
+        float opacity = 0.0f;
+        float3 color = {0.0f, 0.0f, 0.0f};
+        float3 color_grad_factor = {0.0f, 0.0f, 0.0f};
+        if (valid_primitive) {
+            primitive_idx = instance_primitive_indices[instance_idx];
+            mean2d = primitive_mean2d[primitive_idx];
+            const float4 conic_opacity = primitive_conic_opacity[primitive_idx];
+            conic = make_float3(conic_opacity);
+            opacity = conic_opacity.w;
+            const float3 color_unclamped = primitive_color[primitive_idx];
+            color = fmaxf(color_unclamped, 0.0f);
+            if (color_unclamped.x >= 0.0f) color_grad_factor.x = 1.0f;
+            if (color_unclamped.y >= 0.0f) color_grad_factor.y = 1.0f;
+            if (color_unclamped.z >= 0.0f) color_grad_factor.z = 1.0f;
+        }
+        
+        // helpers
+        const float3 background = bg_color[0];
+        const uint n_pixels = width * height;
+
+        // gradient accumulation
+        float2 dL_dmean2d_accum = {0.0f, 0.0f};
+        float3 dL_dconic_accum = {0.0f, 0.0f, 0.0f};
+        float dL_draw_opacity_partial_accum = 0.0f;
+        float3 dL_dcolor_accum = {0.0f, 0.0f, 0.0f};
+
+        // tile metadata
+        const uint2 tile_coords = {tile_idx % grid_width, tile_idx / grid_width};
+        const uint2 start_pixel_coords = {tile_coords.x * config::tile_width, tile_coords.y * config::tile_height};
+
+        uint last_contributor;
+        float3 color_pixel_after;
+        float transmittance;
+        float3 grad_color_pixel;
+        float grad_alpha_common;
+
+        bucket_color_transmittance += bucket_idx * config::block_size_blend;
+        __shared__ uint collected_last_contributor[32];
+        __shared__ float4 collected_color_pixel_after_transmittance[32];
+        __shared__ float4 collected_grad_info_pixel[32];
+
+        // iterate over all pixels in the tile
+        #pragma unroll
+        for (int i = 0; i < config::block_size_blend + 31; ++i) {
+            if (i % 32 == 0) {
+                const uint local_idx = i + lane_idx;
+                const float4 color_transmittance = bucket_color_transmittance[local_idx];
+                const uint2 pixel_coords = {start_pixel_coords.x + local_idx % config::tile_width, start_pixel_coords.y + local_idx / config::tile_width};
+                const uint pixel_idx = width * pixel_coords.y + pixel_coords.x;
+                // final values from forward pass before background blend and the respective gradients
+                float3 color_pixel_w_bg, grad_color_pixel;
+                if (pixel_coords.x < width && pixel_coords.y < height) {
+                    color_pixel_w_bg = make_float3(
+                        image[pixel_idx],
+                        image[n_pixels + pixel_idx],
+                        image[2 * n_pixels + pixel_idx]
+                    );
+                    grad_color_pixel = make_float3(
+                        grad_image[pixel_idx],
+                        grad_image[n_pixels + pixel_idx],
+                        grad_image[2 * n_pixels + pixel_idx]
+                    );
+                }
+                const float final_transmittance = tile_final_transmittances[pixel_idx];
+                collected_color_pixel_after_transmittance[lane_idx] = make_float4(
+                    color_pixel_w_bg - final_transmittance * background - make_float3(color_transmittance),
+                    color_transmittance.w
+                );
+                collected_grad_info_pixel[lane_idx] = make_float4(
+                    grad_color_pixel,
+                    final_transmittance * -dot(grad_color_pixel, background)
+                );
+                collected_last_contributor[lane_idx] = tile_n_contributions[pixel_idx];
+                __syncwarp();
+            }
+
+            if (i > 0) {
+                last_contributor = warp.shfl_up(last_contributor, 1);
+                color_pixel_after.x = warp.shfl_up(color_pixel_after.x, 1);
+                color_pixel_after.y = warp.shfl_up(color_pixel_after.y, 1);
+                color_pixel_after.z = warp.shfl_up(color_pixel_after.z, 1);
+                transmittance = warp.shfl_up(transmittance, 1);
+                grad_color_pixel.x = warp.shfl_up(grad_color_pixel.x, 1);
+                grad_color_pixel.y = warp.shfl_up(grad_color_pixel.y, 1);
+                grad_color_pixel.z = warp.shfl_up(grad_color_pixel.z, 1);
+                grad_alpha_common = warp.shfl_up(grad_alpha_common, 1);
+            }
+
+            // which pixel index should this thread deal with?
+            const int idx = i - static_cast<int>(lane_idx);
+            const uint2 pixel_coords = {start_pixel_coords.x + idx % config::tile_width, start_pixel_coords.y + idx / config::tile_width};
+            const bool valid_pixel = pixel_coords.x < width && pixel_coords.y < height;
+
+            // leader thread loads values from shared memory into registers
+            if (valid_primitive && valid_pixel && lane_idx == 0 && idx < config::block_size_blend) {
+                const int current_shmem_index = i % 32;
+                last_contributor = collected_last_contributor[current_shmem_index];
+                const float4 color_pixel_after_transmittance = collected_color_pixel_after_transmittance[current_shmem_index];
+                color_pixel_after = make_float3(color_pixel_after_transmittance);
+                transmittance = color_pixel_after_transmittance.w;
+                const float4 grad_info_pixel = collected_grad_info_pixel[current_shmem_index];
+                grad_color_pixel = make_float3(grad_info_pixel);
+                grad_alpha_common = grad_info_pixel.w;
+            }
+
+            const bool skip = !valid_primitive || !valid_pixel || idx < 0 || idx >= config::block_size_blend || tile_primitive_idx >= last_contributor;
+            if (skip) continue;
+
+            const float2 pixel = make_float2(__uint2float_rn(pixel_coords.x), __uint2float_rn(pixel_coords.y)) + 0.5f;
+            const float2 delta = mean2d - pixel;
+            const float sigma_over_2 = 0.5f * (conic.x * delta.x * delta.x + conic.z * delta.y * delta.y) + conic.y * delta.x * delta.y;
+            if (sigma_over_2 < 0.0f) continue;
+            const float gaussian = expf(-sigma_over_2);
+            const float alpha = fminf(opacity * gaussian, config::max_fragment_alpha);
+            if (alpha < config::min_alpha_threshold) continue;
+            const float one_minus_alpha = 1.0f - alpha;
+
+            const float blending_weight = transmittance * alpha;
+            
+            // color gradient
+            const float3 dL_dcolor = blending_weight * grad_color_pixel * color_grad_factor;
+            dL_dcolor_accum += dL_dcolor;
+
+            color_pixel_after -= blending_weight * color;
+
+            // alpha gradient
+            const float one_minus_alpha_rcp = 1.0f / one_minus_alpha;
+            const float dL_dalpha_from_color = dot(transmittance * color - color_pixel_after * one_minus_alpha_rcp, grad_color_pixel);
+            const float dL_dalpha_from_alpha = grad_alpha_common * one_minus_alpha_rcp;
+            const float dL_dalpha = dL_dalpha_from_color + dL_dalpha_from_alpha;
+            // unactivated opacity gradient
+            const float dL_draw_opacity_partial = alpha * dL_dalpha;
+            dL_draw_opacity_partial_accum += dL_draw_opacity_partial;
+
+            // conic and mean2d gradient
+            const float gaussian_grad_helper = -alpha * dL_dalpha;
+            const float3 dL_dconic = 0.5f * gaussian_grad_helper * make_float3(
+                delta.x * delta.x,
+                delta.x * delta.y,
+                delta.y * delta.y
+            );
+            dL_dconic_accum += dL_dconic;
+            const float2 dL_dmean2d = gaussian_grad_helper * make_float2(
+                conic.x * delta.x + conic.y * delta.y,
+                conic.y * delta.x + conic.z * delta.y
+            );
+            dL_dmean2d_accum += dL_dmean2d;
+
+            transmittance *= one_minus_alpha;
+        }
+
+        // finally add the gradients using atomics
+        if (valid_primitive) {
+            atomicAdd(&grad_mean2d[primitive_idx].x, dL_dmean2d_accum.x);
+            atomicAdd(&grad_mean2d[primitive_idx].y, dL_dmean2d_accum.y);
+            atomicAdd(&grad_conic[primitive_idx], dL_dconic_accum.x);
+            atomicAdd(&grad_conic[n_primitives + primitive_idx], dL_dconic_accum.y);
+            atomicAdd(&grad_conic[2 * n_primitives + primitive_idx], dL_dconic_accum.z);
+            const float dL_draw_opacity = dL_draw_opacity_partial_accum * (1.0f - opacity);
+            atomicAdd(&grad_raw_opacity[primitive_idx], dL_draw_opacity);
+            atomicAdd(&grad_color[primitive_idx].x, dL_dcolor_accum.x);
+            atomicAdd(&grad_color[primitive_idx].y, dL_dcolor_accum.y);
+            atomicAdd(&grad_color[primitive_idx].z, dL_dcolor_accum.z);
+        }
+    }
+
+}

--- a/fastgs/rasterization/include/kernels_forward.cuh
+++ b/fastgs/rasterization/include/kernels_forward.cuh
@@ -1,0 +1,455 @@
+#pragma once
+
+#include "rasterization_config.h"
+#include "kernel_utils.cuh"
+#include "buffer_utils.h"
+#include "helper_math.h"
+#include "utils.h"
+#include <cstdint>
+#include <cooperative_groups.h>
+namespace cg = cooperative_groups;
+
+namespace fast_gs::rasterization::kernels::forward {
+
+    __global__ void preprocess_cu(
+        const float3* means,
+        const float3* raw_scales,
+        const float4* raw_rotations,
+        const float* raw_opacities,
+        const float3* sh_coefficients_0,
+        const float3* sh_coefficients_rest,
+        const float4* w2c,
+        const float3* cam_position,
+        uint* primitive_depth_keys,
+        uint* primitive_indices,
+        uint* primitive_n_touched_tiles,
+        ushort4* primitive_screen_bounds,
+        float2* primitive_mean2d,
+        float4* primitive_conic_opacity,
+        float3* primitive_color,
+        uint* n_visible_primitives,
+        uint* n_instances,
+        const uint n_primitives,
+        const uint grid_width,
+        const uint grid_height,
+        const uint active_sh_bases,
+        const uint total_bases_sh_rest,
+        const float w,
+        const float h,
+        const float fx,
+        const float fy,
+        const float cx,
+        const float cy,
+        const float near,
+        const float far)
+    {
+        auto primitive_idx = cg::this_grid().thread_rank();
+        bool active = true;
+        if (primitive_idx >= n_primitives) {
+            active = false;
+            primitive_idx = n_primitives - 1;
+        }
+
+        if (active) primitive_n_touched_tiles[primitive_idx] = 0;
+
+        // load 3d mean
+        const float3 mean3d = means[primitive_idx];
+
+        // z culling
+        const float4 w2c_r3 = w2c[2];
+        const float depth = w2c_r3.x * mean3d.x + w2c_r3.y * mean3d.y + w2c_r3.z * mean3d.z + w2c_r3.w;
+        if (depth < near || depth > far) active = false;
+
+        // early exit if whole warp is inactive
+        if (__ballot_sync(0xffffffffu, active) == 0) return;
+
+        // load opacity
+        const float raw_opacity = raw_opacities[primitive_idx];
+        const float opacity = 1.0f / (1.0f + expf(-raw_opacity));
+        if (opacity < config::min_alpha_threshold) active = false;
+
+        // compute 3d covariance from raw scale and rotation
+        const float3 raw_scale = raw_scales[primitive_idx];
+        const float3 variance = make_float3(expf(2.0f * raw_scale.x), expf(2.0f * raw_scale.y), expf(2.0f * raw_scale.z));
+        auto [qr, qx, qy, qz] = raw_rotations[primitive_idx];
+        const float qrr_raw = qr * qr, qxx_raw = qx * qx, qyy_raw = qy * qy, qzz_raw = qz * qz;
+        const float q_norm_sq = qrr_raw + qxx_raw + qyy_raw + qzz_raw;
+        if (q_norm_sq < 1e-8f) active = false;
+        const float qxx = 2.0f * qxx_raw / q_norm_sq, qyy = 2.0f * qyy_raw / q_norm_sq, qzz = 2.0f * qzz_raw / q_norm_sq;
+        const float qxy = 2.0f * qx * qy / q_norm_sq, qxz = 2.0f * qx * qz / q_norm_sq, qyz = 2.0f * qy * qz / q_norm_sq;
+        const float qrx = 2.0f * qr * qx / q_norm_sq, qry = 2.0f * qr * qy / q_norm_sq, qrz = 2.0f * qr * qz / q_norm_sq;
+        const mat3x3 rotation = {
+            1.0f - (qyy + qzz), qxy - qrz, qry + qxz,
+            qrz + qxy, 1.0f - (qxx + qzz), qyz - qrx,
+            qxz - qry, qrx + qyz, 1.0f - (qxx + qyy)
+        };
+        const mat3x3 rotation_scaled = {
+            rotation.m11 * variance.x, rotation.m12 * variance.y, rotation.m13 * variance.z,
+            rotation.m21 * variance.x, rotation.m22 * variance.y, rotation.m23 * variance.z,
+            rotation.m31 * variance.x, rotation.m32 * variance.y, rotation.m33 * variance.z
+        };
+        const mat3x3_triu cov3d {
+            rotation_scaled.m11 * rotation.m11 + rotation_scaled.m12 * rotation.m12 + rotation_scaled.m13 * rotation.m13,
+            rotation_scaled.m11 * rotation.m21 + rotation_scaled.m12 * rotation.m22 + rotation_scaled.m13 * rotation.m23,
+            rotation_scaled.m11 * rotation.m31 + rotation_scaled.m12 * rotation.m32 + rotation_scaled.m13 * rotation.m33,
+            rotation_scaled.m21 * rotation.m21 + rotation_scaled.m22 * rotation.m22 + rotation_scaled.m23 * rotation.m23,
+            rotation_scaled.m21 * rotation.m31 + rotation_scaled.m22 * rotation.m32 + rotation_scaled.m23 * rotation.m33,
+            rotation_scaled.m31 * rotation.m31 + rotation_scaled.m32 * rotation.m32 + rotation_scaled.m33 * rotation.m33,
+        };
+
+        // compute 2d mean in normalized image coordinates
+        const float4 w2c_r1 = w2c[0];
+        const float x = (w2c_r1.x * mean3d.x + w2c_r1.y * mean3d.y + w2c_r1.z * mean3d.z + w2c_r1.w) / depth;
+        const float4 w2c_r2 = w2c[1];
+        const float y = (w2c_r2.x * mean3d.x + w2c_r2.y * mean3d.y + w2c_r2.z * mean3d.z + w2c_r2.w) / depth;
+
+        // ewa splatting
+        const float clip_left = (-0.15f * w - cx) / fx;
+        const float clip_right = (1.15f * w - cx) / fx;
+        const float clip_top = (-0.15f * h - cy) / fy;
+        const float clip_bottom = (1.15f * h - cy) / fy;
+        const float tx = clamp(x, clip_left, clip_right);
+        const float ty = clamp(y, clip_top, clip_bottom);
+        const float j11 = fx / depth;
+        const float j13 = -j11 * tx;
+        const float j22 = fy / depth;
+        const float j23 = -j22 * ty;
+        const float3 jw_r1 = make_float3(
+            j11 * w2c_r1.x + j13 * w2c_r3.x,
+            j11 * w2c_r1.y + j13 * w2c_r3.y,
+            j11 * w2c_r1.z + j13 * w2c_r3.z
+        );
+        const float3 jw_r2 = make_float3(
+            j22 * w2c_r2.x + j23 * w2c_r3.x,
+            j22 * w2c_r2.y + j23 * w2c_r3.y,
+            j22 * w2c_r2.z + j23 * w2c_r3.z
+        );
+        const float3 jwc_r1 = make_float3(
+            jw_r1.x * cov3d.m11 + jw_r1.y * cov3d.m12 + jw_r1.z * cov3d.m13,
+            jw_r1.x * cov3d.m12 + jw_r1.y * cov3d.m22 + jw_r1.z * cov3d.m23,
+            jw_r1.x * cov3d.m13 + jw_r1.y * cov3d.m23 + jw_r1.z * cov3d.m33
+        );
+        const float3 jwc_r2 = make_float3(
+            jw_r2.x * cov3d.m11 + jw_r2.y * cov3d.m12 + jw_r2.z * cov3d.m13,
+            jw_r2.x * cov3d.m12 + jw_r2.y * cov3d.m22 + jw_r2.z * cov3d.m23,
+            jw_r2.x * cov3d.m13 + jw_r2.y * cov3d.m23 + jw_r2.z * cov3d.m33
+        );
+        float3 cov2d = make_float3(
+            dot(jwc_r1, jw_r1),
+            dot(jwc_r1, jw_r2),
+            dot(jwc_r2, jw_r2)
+        );
+        cov2d.x += config::dilation;
+        cov2d.z += config::dilation;
+        const float determinant = cov2d.x * cov2d.z - cov2d.y * cov2d.y;
+        if (determinant < 1e-8f) active = false;
+        const float3 conic = make_float3(
+            cov2d.z / determinant,
+            -cov2d.y / determinant,
+            cov2d.x / determinant
+        );
+
+        // 2d mean in screen space
+        const float2 mean2d = make_float2(
+            x * fx + cx,
+            y * fy + cy
+        );
+
+        // compute bounds
+        const float power_threshold = logf(opacity * config::min_alpha_threshold_rcp);
+        const float power_threshold_factor = sqrtf(2.0f * power_threshold);
+        float extent_x = fmaxf(power_threshold_factor * sqrtf(cov2d.x) - 0.5f, 0.0f);
+        float extent_y = fmaxf(power_threshold_factor * sqrtf(cov2d.z) - 0.5f, 0.0f);
+        const uint4 screen_bounds = make_uint4(
+            min(grid_width, static_cast<uint>(max(0, __float2int_rd((mean2d.x - extent_x) / static_cast<float>(config::tile_width))))), // x_min
+            min(grid_width, static_cast<uint>(max(0, __float2int_ru((mean2d.x + extent_x) / static_cast<float>(config::tile_width))))), // x_max
+            min(grid_height, static_cast<uint>(max(0, __float2int_rd((mean2d.y - extent_y) / static_cast<float>(config::tile_height))))), // y_min
+            min(grid_height, static_cast<uint>(max(0, __float2int_ru((mean2d.y + extent_y) / static_cast<float>(config::tile_height))))) // y_max
+        );
+        const uint n_touched_tiles_max = (screen_bounds.y - screen_bounds.x) * (screen_bounds.w - screen_bounds.z);
+        if (n_touched_tiles_max == 0) active = false;
+
+        // early exit if whole warp is inactive
+        if (__ballot_sync(0xffffffffu, active) == 0) return;
+
+        // compute exact number of tiles the primitive overlaps
+        const uint n_touched_tiles = compute_exact_n_touched_tiles(
+            mean2d, conic, screen_bounds,
+            power_threshold, n_touched_tiles_max, active);
+
+         // cooperative threads no longer needed
+        if (n_touched_tiles == 0 || !active) return;
+
+        // store results
+        primitive_n_touched_tiles[primitive_idx] = n_touched_tiles;
+        primitive_screen_bounds[primitive_idx] = make_ushort4(
+            static_cast<ushort>(screen_bounds.x),
+            static_cast<ushort>(screen_bounds.y),
+            static_cast<ushort>(screen_bounds.z),
+            static_cast<ushort>(screen_bounds.w)
+        );
+        primitive_mean2d[primitive_idx] = mean2d;
+        primitive_conic_opacity[primitive_idx] = make_float4(conic, opacity);
+        primitive_color[primitive_idx] = convert_sh_to_color(
+            sh_coefficients_0, sh_coefficients_rest,
+            mean3d, cam_position[0],
+            primitive_idx, active_sh_bases, total_bases_sh_rest);
+
+        const uint offset = atomicAdd(n_visible_primitives, 1);
+        const uint depth_key = __float_as_uint(depth);
+        primitive_depth_keys[offset] = depth_key;
+        primitive_indices[offset] = primitive_idx;
+        atomicAdd(n_instances, n_touched_tiles);
+    }
+
+    __global__ void apply_depth_ordering_cu(
+        const uint* primitive_indices_sorted,
+        const uint* primitive_n_touched_tiles,
+        uint* primitive_offset,
+        const uint n_visible_primitives)
+    {
+        auto idx = cg::this_grid().thread_rank();
+        if (idx >= n_visible_primitives) return;
+        const uint primitive_idx = primitive_indices_sorted[idx];
+        primitive_offset[idx] = primitive_n_touched_tiles[primitive_idx];
+    }
+
+    // based on https://github.com/r4dl/StopThePop-Rasterization/blob/d8cad09919ff49b11be3d693d1e71fa792f559bb/cuda_rasterizer/stopthepop/stopthepop_common.cuh#L325
+    __global__ void create_instances_cu(
+        const uint* primitive_indices_sorted,
+        const uint* primitive_offsets,
+        const ushort4* primitive_screen_bounds,
+        const float2* primitive_mean2d,
+        const float4* primitive_conic_opacity,
+        ushort* instance_keys,
+        uint* instance_primitive_indices,
+        const uint grid_width,
+        const uint n_visible_primitives)
+    {
+        auto block = cg::this_thread_block();
+        auto warp = cg::tiled_partition<32u>(block);
+        uint idx = cg::this_grid().thread_rank();
+
+        bool active = true;
+        if (idx >= n_visible_primitives) {
+            active = false;
+            idx = n_visible_primitives - 1;
+        }
+
+        if (__ballot_sync(0xffffffffu, active) == 0) return;
+
+        const uint primitive_idx = primitive_indices_sorted[idx];
+        
+        const ushort4 screen_bounds = primitive_screen_bounds[primitive_idx];
+        const uint screen_bounds_width = static_cast<uint>(screen_bounds.y - screen_bounds.x);
+        const uint tile_count = static_cast<uint>(screen_bounds.w - screen_bounds.z) * screen_bounds_width;
+
+        __shared__ ushort4 collected_screen_bounds[config::block_size_create_instances];
+        __shared__ float2 collected_mean2d_shifted[config::block_size_create_instances];
+        __shared__ float4 collected_conic_opacity[config::block_size_create_instances];
+        collected_screen_bounds[block.thread_rank()] = screen_bounds;
+        collected_mean2d_shifted[block.thread_rank()] = primitive_mean2d[primitive_idx] - 0.5f;
+        collected_conic_opacity[block.thread_rank()] = primitive_conic_opacity[primitive_idx];
+
+        uint current_write_offset = primitive_offsets[idx];
+        
+        if (active) {
+            const float2 mean2d_shifted = collected_mean2d_shifted[block.thread_rank()];
+            const float4 conic_opacity = collected_conic_opacity[block.thread_rank()];
+            const float3 conic = make_float3(conic_opacity);
+            const float power_threshold = logf(conic_opacity.w * config::min_alpha_threshold_rcp);
+
+            for (uint instance_idx = 0; instance_idx < tile_count && instance_idx < config::n_sequential_threshold; instance_idx++) {
+                const uint tile_y = screen_bounds.z + (instance_idx / screen_bounds_width);
+                const uint tile_x = screen_bounds.x + (instance_idx % screen_bounds_width);
+                if (will_primitive_contribute(mean2d_shifted, conic, tile_x, tile_y, power_threshold)) {
+                    const ushort tile_key = static_cast<ushort>(tile_y * grid_width + tile_x);
+                    instance_keys[current_write_offset] = tile_key;
+                    instance_primitive_indices[current_write_offset] = primitive_idx;
+                    current_write_offset++;
+                }
+            }
+        }
+
+        const uint lane_idx = cg::this_thread_block().thread_rank() % 32u;
+        const uint warp_idx = cg::this_thread_block().thread_rank() / 32u;
+        const uint lane_mask_allprev_excl = 0xffffffffu >> (32u - lane_idx);
+        const int compute_cooperatively = active && tile_count > config::n_sequential_threshold;
+        const uint remaining_threads = __ballot_sync(0xffffffffu, compute_cooperatively);
+        if (remaining_threads == 0) return;
+
+        const uint n_remaining_threads = __popc(remaining_threads);
+        for (int n = 0; n < n_remaining_threads && n < 32; n++) {
+            int current_lane = __fns(remaining_threads, 0, n + 1);
+            uint primitive_idx_coop = __shfl_sync(0xffffffffu, primitive_idx, current_lane);
+            uint current_write_offset_coop = __shfl_sync(0xffffffffu, current_write_offset, current_lane);
+
+            const ushort4 screen_bounds_coop = collected_screen_bounds[warp.meta_group_rank() * 32 + current_lane];
+            const uint screen_bounds_width_coop = static_cast<uint>(screen_bounds_coop.y - screen_bounds_coop.x);
+            const uint tile_count_coop = screen_bounds_width_coop * static_cast<uint>(screen_bounds_coop.w - screen_bounds_coop.z);
+
+            const float2 mean2d_shifted_coop = collected_mean2d_shifted[warp.meta_group_rank() * 32 + current_lane];
+            const float4 conic_opacity_coop = collected_conic_opacity[warp.meta_group_rank() * 32 + current_lane];
+            const float3 conic_coop = make_float3(conic_opacity_coop);
+            const float power_threshold_coop = logf(conic_opacity_coop.w * config::min_alpha_threshold_rcp);
+
+            const uint remaining_tile_count = tile_count_coop - config::n_sequential_threshold;
+            const int n_iterations = div_round_up(remaining_tile_count, 32u);
+            for (int i = 0; i < n_iterations; i++) {
+                const int instance_idx = i * 32 + lane_idx + config::n_sequential_threshold;
+                const int active_current = instance_idx < tile_count_coop;
+                const uint tile_y = screen_bounds_coop.z + (instance_idx / screen_bounds_width_coop);
+                const uint tile_x = screen_bounds_coop.x + (instance_idx % screen_bounds_width_coop);
+                const uint write = active_current && will_primitive_contribute(mean2d_shifted_coop, conic_coop, tile_x, tile_y, power_threshold_coop);
+                const uint write_ballot = __ballot_sync(0xffffffffu, write);
+                const uint n_writes = __popc(write_ballot);
+                const uint write_offset_current = __popc(write_ballot & lane_mask_allprev_excl);
+                const uint write_offset = current_write_offset_coop + write_offset_current;
+                if (write) {
+                    const ushort tile_key = static_cast<ushort>(tile_y * grid_width + tile_x);
+                    instance_keys[write_offset] = tile_key;
+                    instance_primitive_indices[write_offset] = primitive_idx_coop;
+                }
+                current_write_offset_coop += n_writes;
+            }
+
+            __syncwarp();
+        }
+    }
+
+    __global__ void extract_instance_ranges_cu(
+        const ushort* instance_keys,
+        uint2* tile_instance_ranges,
+        const uint n_instances)
+    {
+        auto instance_idx = cg::this_grid().thread_rank();
+        if (instance_idx >= n_instances) return;
+        const ushort instance_tile_idx = instance_keys[instance_idx];
+        if (instance_idx == 0) tile_instance_ranges[instance_tile_idx].x = 0;
+        else {
+            const ushort previous_instance_tile_idx = instance_keys[instance_idx - 1];
+            if (instance_tile_idx != previous_instance_tile_idx) {
+                tile_instance_ranges[previous_instance_tile_idx].y = instance_idx;
+                tile_instance_ranges[instance_tile_idx].x = instance_idx;
+            }
+        }
+        if (instance_idx == n_instances - 1) tile_instance_ranges[instance_tile_idx].y = n_instances;
+    }
+
+    __global__ void extract_bucket_counts(
+        uint2* tile_instance_ranges,
+        uint* tile_n_buckets,
+        const uint n_tiles)
+    {
+        auto tile_idx = cg::this_grid().thread_rank();
+        if (tile_idx >= n_tiles) return;
+        const uint2 instance_range = tile_instance_ranges[tile_idx];
+        const uint n_buckets = div_round_up(instance_range.y - instance_range.x, 32u);
+        tile_n_buckets[tile_idx] = n_buckets;
+    }
+
+    __global__ void __launch_bounds__(config::block_size_blend) blend_cu(
+        const uint2* tile_instance_ranges,
+        const uint* tile_bucket_offsets,
+        const uint* instance_primitive_indices,
+        const float2* primitive_mean2d,
+        const float4* primitive_conic_opacity,
+        const float3* primitive_color,
+        const float3* bg_color,
+        float* image,
+        float* tile_final_transmittances,
+        uint* tile_max_n_contributions,
+        uint* tile_n_contributions,
+        uint* bucket_tile_index,
+        float4* bucket_color_transmittance,
+        const uint width,
+        const uint height,
+        const uint grid_width)
+    {
+        auto block = cg::this_thread_block();
+        const dim3 group_index = block.group_index();
+        const dim3 thread_index = block.thread_index();
+        const uint thread_rank = block.thread_rank();
+        const uint2 pixel_coords = make_uint2(group_index.x * config::tile_width + thread_index.x, group_index.y * config::tile_height + thread_index.y);
+        const bool inside = pixel_coords.x < width && pixel_coords.y < height;
+        const float2 pixel = make_float2(__uint2float_rn(pixel_coords.x), __uint2float_rn(pixel_coords.y)) + 0.5f;
+
+        const uint tile_idx = group_index.y * grid_width + group_index.x;
+        const uint2 tile_range = tile_instance_ranges[tile_idx];
+        const int n_points_total = tile_range.y - tile_range.x;
+
+        uint bucket_offset = tile_idx == 0 ? 0 : tile_bucket_offsets[tile_idx - 1];
+        const int n_buckets = div_round_up(n_points_total, 32); // re-computing is faster than reading from tile_n_buckets
+        for (int n_buckets_remaining = n_buckets, current_bucket_idx = thread_rank; n_buckets_remaining > 0; n_buckets_remaining -= config::block_size_blend, current_bucket_idx += config::block_size_blend) {
+            if (current_bucket_idx < n_buckets) bucket_tile_index[bucket_offset + current_bucket_idx] = tile_idx;
+        }
+
+        // setup shared memory
+        __shared__ float2 collected_mean2d[config::block_size_blend];
+        __shared__ float4 collected_conic_opacity[config::block_size_blend];
+        __shared__ float3 collected_color[config::block_size_blend];
+        // initialize local storage
+        float3 color_pixel = make_float3(0.0f);
+        float transmittance = 1.0f;
+        uint n_possible_contributions = 0;
+        uint n_contributions = 0;
+        bool done = !inside;
+        // collaborative loading and processing
+        for (int n_points_remaining = n_points_total, current_fetch_idx = tile_range.x + thread_rank; n_points_remaining > 0; n_points_remaining -= config::block_size_blend, current_fetch_idx += config::block_size_blend) {
+            if (__syncthreads_count(done) == config::block_size_blend) break;
+            if (current_fetch_idx < tile_range.y) {
+                const uint primitive_idx = instance_primitive_indices[current_fetch_idx];
+                collected_mean2d[thread_rank] = primitive_mean2d[primitive_idx];
+                collected_conic_opacity[thread_rank] = primitive_conic_opacity[primitive_idx];
+                const float3 color = fmaxf(primitive_color[primitive_idx], 0.0f);
+                collected_color[thread_rank] = color;
+            }
+            block.sync();
+            const int current_batch_size = min(config::block_size_blend, n_points_remaining);
+            for (int j = 0; !done && j < current_batch_size; ++j) {
+                if (j % 32 == 0) {
+                    const float4 current_color_transmittance = make_float4(color_pixel, transmittance);
+                    bucket_color_transmittance[bucket_offset * config::block_size_blend + thread_rank] = current_color_transmittance;
+                    bucket_offset++;
+                }
+                n_possible_contributions++;
+                const float4 conic_opacity = collected_conic_opacity[j];
+                const float3 conic = make_float3(conic_opacity);
+                const float2 delta = collected_mean2d[j] - pixel;
+                const float opacity = conic_opacity.w;
+                const float sigma_over_2 = 0.5f * (conic.x * delta.x * delta.x + conic.z * delta.y * delta.y) + conic.y * delta.x * delta.y;
+                if (sigma_over_2 < 0.0f) continue;
+                const float gaussian = expf(-sigma_over_2);
+                const float alpha = fminf(opacity * gaussian, config::max_fragment_alpha);
+                if (alpha < config::min_alpha_threshold) continue;
+                const float next_transmittance = transmittance * (1.0f - alpha);
+                if (next_transmittance < config::transmittance_threshold) {
+                    done = true;
+                    continue;
+                }
+                color_pixel += transmittance * alpha * collected_color[j];
+                transmittance = next_transmittance;
+                n_contributions = n_possible_contributions;
+            }
+        }
+        if (inside) {
+            const int pixel_idx = width * pixel_coords.y + pixel_coords.x;
+            const int n_pixels = width * height;
+            // apply background color
+            color_pixel += transmittance * bg_color[0];
+            // store results
+            image[pixel_idx] = color_pixel.x;
+            image[pixel_idx + n_pixels] = color_pixel.y;
+            image[pixel_idx + n_pixels * 2] = color_pixel.z;
+            tile_final_transmittances[pixel_idx] = transmittance;
+            tile_n_contributions[pixel_idx] = n_contributions;
+        }
+
+        // max reduce the number of contributions
+        typedef cub::BlockReduce<uint, config::tile_width, cub::BLOCK_REDUCE_WARP_REDUCTIONS, config::tile_height> BlockReduce;
+        __shared__ typename BlockReduce::TempStorage temp_storage;
+        n_contributions = BlockReduce(temp_storage).Reduce(n_contributions, cub::Max());
+        if (thread_rank == 0) tile_max_n_contributions[tile_idx] = n_contributions;
+    }
+
+}

--- a/fastgs/rasterization/include/rasterization_api.h
+++ b/fastgs/rasterization/include/rasterization_api.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <torch/extension.h>
+#include <tuple>
+
+namespace fast_gs::rasterization {
+
+    struct FastGSSettings {
+        torch::Tensor w2c;
+        torch::Tensor cam_position;
+        torch::Tensor bg_color;
+        int active_sh_bases;
+        int width;
+        int height;
+        float focal_x;
+        float focal_y;
+        float center_x;
+        float center_y;
+        float near_plane;
+        float far_plane;
+    };
+
+    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, int, int, int, int, int>
+    forward_wrapper(
+        const torch::Tensor& means,
+        const torch::Tensor& scales_raw,
+        const torch::Tensor& rotations_raw,
+        const torch::Tensor& opacities_raw,
+        const torch::Tensor& sh_coefficients_0,
+        const torch::Tensor& sh_coefficients_rest,
+        const torch::Tensor& w2c,
+        const torch::Tensor& cam_position,
+        const torch::Tensor& bg_color,
+        const int active_sh_bases,
+        const int width,
+        const int height,
+        const float focal_x,
+        const float focal_y,
+        const float center_x,
+        const float center_y,
+        const float near_plane,
+        const float far_plane);
+    
+    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+    backward_wrapper(
+        torch::Tensor& densification_info,
+        const torch::Tensor& grad_image,
+        const torch::Tensor& image,
+        const torch::Tensor& means,
+        const torch::Tensor& scales_raw,
+        const torch::Tensor& rotations_raw,
+        const torch::Tensor& sh_coefficients_rest,
+        const torch::Tensor& per_primitive_buffers,
+        const torch::Tensor& per_tile_buffers,
+        const torch::Tensor& per_instance_buffers,
+        const torch::Tensor& per_bucket_buffers,
+        const torch::Tensor& w2c,
+        const torch::Tensor& cam_position,
+        const torch::Tensor& bg_color,
+        const int active_sh_bases,
+        const int width,
+        const int height,
+        const float focal_x,
+        const float focal_y,
+        const float center_x,
+        const float center_y,
+        const float near_plane,
+        const float far_plane,
+        const int n_visible_primitives,
+        const int n_instances,
+        const int n_buckets,
+        const int primitive_primitive_indices_selector,
+        const int instance_primitive_indices_selector);
+
+}

--- a/fastgs/rasterization/include/rasterization_config.h
+++ b/fastgs/rasterization/include/rasterization_config.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "helper_math.h"
+
+#define DEF inline constexpr
+
+namespace fast_gs::rasterization::config {
+    DEF bool debug = false;
+    // rendering constants
+    DEF float dilation = 0.3f;
+    DEF float min_alpha_threshold_rcp = 255.0f;
+    DEF float min_alpha_threshold = 1.0f / min_alpha_threshold_rcp; // 0.00392156862
+    DEF float max_fragment_alpha = 0.999f; // 0.99f in original 3dgs
+    DEF float transmittance_threshold = 1e-4f;
+    // block size constants
+    DEF int block_size_preprocess = 128;
+    DEF int block_size_preprocess_backward = 128;
+    DEF int block_size_apply_depth_ordering = 256;
+    DEF int block_size_create_instances = 256;
+    DEF int block_size_extract_instance_ranges = 256;
+    DEF int block_size_extract_bucket_counts = 256;
+    DEF int tile_width = 16;
+    DEF int tile_height = 16;
+    DEF int block_size_blend = tile_width * tile_height;
+    DEF int n_sequential_threshold = 4;
+}
+
+namespace config = fast_gs::rasterization::config;
+
+#undef DEF

--- a/fastgs/rasterization/src/backward.cu
+++ b/fastgs/rasterization/src/backward.cu
@@ -1,0 +1,114 @@
+#include "backward.h"
+#include "kernels_backward.cuh"
+#include "buffer_utils.h"
+#include "rasterization_config.h"
+#include "utils.h"
+#include "helper_math.h"
+#include <cub/cub.cuh>
+#include <functional>
+
+
+void fast_gs::rasterization::backward(
+    const float* grad_image,
+    const float* image,
+    const float3* means,
+    const float3* scales_raw,
+    const float4* rotations_raw,
+    const float3* sh_coefficients_rest,
+    const float4* w2c,
+    const float3* cam_position,
+    const float3* bg_color,
+    char* per_primitive_buffers_blob,
+    char* per_tile_buffers_blob,
+    char* per_instance_buffers_blob,
+    char* per_bucket_buffers_blob,
+    float3* grad_means,
+    float3* grad_scales_raw,
+    float4* grad_rotations_raw,
+    float* grad_opacities_raw,
+    float3* grad_sh_coefficients_0,
+    float3* grad_sh_coefficients_rest,
+    float2* grad_mean2d_helper,
+    float* grad_conic_helper,
+    float* densification_info,
+    const int n_primitives,
+    const int n_visible_primitives,
+    const int n_instances,
+    const int n_buckets,
+    const int primitive_primitive_indices_selector,
+    const int instance_primitive_indices_selector,
+    const int active_sh_bases,
+    const int total_bases_sh_rest,
+    const int width,
+    const int height,
+    const float fx,
+    const float fy,
+    const float cx,
+    const float cy)
+{
+    const dim3 grid(div_round_up(width, config::tile_width), div_round_up(height, config::tile_height), 1);
+    const int n_tiles = grid.x * grid.y;
+
+    PerPrimitiveBuffers per_primitive_buffers = PerPrimitiveBuffers::from_blob(per_primitive_buffers_blob, n_primitives);
+    PerTileBuffers per_tile_buffers = PerTileBuffers::from_blob(per_tile_buffers_blob, n_tiles);
+    PerInstanceBuffers per_instance_buffers = PerInstanceBuffers::from_blob(per_instance_buffers_blob, n_instances);
+    PerBucketBuffers per_bucket_buffers = PerBucketBuffers::from_blob(per_bucket_buffers_blob, n_buckets);
+    per_primitive_buffers.primitive_indices.selector = primitive_primitive_indices_selector;
+    per_instance_buffers.primitive_indices.selector = instance_primitive_indices_selector;
+
+    kernels::backward::blend_backward_cu<<<n_buckets, 32>>>(
+        per_tile_buffers.instance_ranges,
+        per_tile_buffers.bucket_offsets,
+        per_instance_buffers.primitive_indices.Current(),
+        per_primitive_buffers.mean2d,
+        per_primitive_buffers.conic_opacity,
+        per_primitive_buffers.color,
+        bg_color,
+        grad_image,
+        image,
+        per_tile_buffers.final_transmittances,
+        per_tile_buffers.max_n_contributions,
+        per_tile_buffers.n_contributions,
+        per_bucket_buffers.tile_index,
+        per_bucket_buffers.color_transmittance,
+        grad_mean2d_helper,
+        grad_conic_helper,
+        grad_opacities_raw,
+        grad_sh_coefficients_0, // used to store intermediate gradients
+        n_buckets,
+        n_primitives,
+        width,
+        height,
+        grid.x
+    );
+    CHECK_CUDA(config::debug, "blend_backward")
+
+    kernels::backward::preprocess_backward_cu<<<div_round_up(n_primitives, config::block_size_preprocess_backward), config::block_size_preprocess_backward>>>(
+        means,
+        scales_raw,
+        rotations_raw,
+        sh_coefficients_rest,
+        w2c,
+        cam_position,
+        per_primitive_buffers.n_touched_tiles,
+        grad_mean2d_helper,
+        grad_conic_helper,
+        grad_means,
+        grad_scales_raw,
+        grad_rotations_raw,
+        grad_sh_coefficients_0,
+        grad_sh_coefficients_rest,
+        densification_info,
+        n_primitives,
+        active_sh_bases,
+        total_bases_sh_rest,
+        static_cast<float>(width),
+        static_cast<float>(height),
+        fx,
+        fy,
+        cx,
+        cy
+    );
+    CHECK_CUDA(config::debug, "preprocess_backward")
+
+}

--- a/fastgs/rasterization/src/forward.cu
+++ b/fastgs/rasterization/src/forward.cu
@@ -1,0 +1,207 @@
+#include "forward.h"
+#include "kernels_forward.cuh"
+#include "buffer_utils.h"
+#include "rasterization_config.h"
+#include "utils.h"
+#include "helper_math.h"
+#include <cub/cub.cuh>
+#include <functional>
+
+
+// sorting is done separately for depth and tile as proposed in https://github.com/m-schuetz/Splatshop
+std::tuple<int, int, int, int, int> fast_gs::rasterization::forward(
+    std::function<char* (size_t)> per_primitive_buffers_func,
+    std::function<char* (size_t)> per_tile_buffers_func,
+    std::function<char* (size_t)> per_instance_buffers_func,
+    std::function<char* (size_t)> per_bucket_buffers_func,
+    const float3* means,
+    const float3* scales_raw,
+    const float4* rotations_raw,
+    const float* opacities_raw,
+    const float3* sh_coefficients_0,
+    const float3* sh_coefficients_rest,
+    const float4* w2c,
+    const float3* cam_position,
+    const float3* bg_color,
+    float* image,
+    const int n_primitives,
+    const int active_sh_bases,
+    const int total_bases_sh_rest,
+    const int width,
+    const int height,
+    const float fx,
+    const float fy,
+    const float cx,
+    const float cy,
+    const float near,
+    const float far)
+{
+    const dim3 grid(div_round_up(width, config::tile_width), div_round_up(height, config::tile_height), 1);
+    const dim3 block(config::tile_width, config::tile_height, 1);
+    const int n_tiles = grid.x * grid.y;
+
+    char* per_tile_buffers_blob = per_tile_buffers_func(required<PerTileBuffers>(n_tiles));
+    PerTileBuffers per_tile_buffers = PerTileBuffers::from_blob(per_tile_buffers_blob, n_tiles);
+
+    static cudaStream_t memset_stream = 0;
+    if constexpr (!config::debug) {
+        static bool memset_stream_initialized = false;
+        if (!memset_stream_initialized) {
+            cudaStreamCreate(&memset_stream);
+            memset_stream_initialized = true;
+        }
+        cudaMemsetAsync(per_tile_buffers.instance_ranges, 0, sizeof(uint2) * n_tiles, memset_stream);
+    }
+    else cudaMemset(per_tile_buffers.instance_ranges, 0, sizeof(uint2) * n_tiles);
+
+    char* per_primitive_buffers_blob = per_primitive_buffers_func(required<PerPrimitiveBuffers>(n_primitives));
+    PerPrimitiveBuffers per_primitive_buffers = PerPrimitiveBuffers::from_blob(per_primitive_buffers_blob, n_primitives);
+
+    cudaMemset(per_primitive_buffers.n_visible_primitives, 0, sizeof(uint));
+    cudaMemset(per_primitive_buffers.n_instances, 0, sizeof(uint));
+
+    kernels::forward::preprocess_cu<<<div_round_up(n_primitives, config::block_size_preprocess), config::block_size_preprocess>>>(
+        means,
+        scales_raw,
+        rotations_raw,
+        opacities_raw,
+        sh_coefficients_0,
+        sh_coefficients_rest,
+        w2c,
+        cam_position,
+        per_primitive_buffers.depth_keys.Current(),
+        per_primitive_buffers.primitive_indices.Current(),
+        per_primitive_buffers.n_touched_tiles,
+        per_primitive_buffers.screen_bounds,
+        per_primitive_buffers.mean2d,
+        per_primitive_buffers.conic_opacity,
+        per_primitive_buffers.color,
+        per_primitive_buffers.n_visible_primitives,
+        per_primitive_buffers.n_instances,
+        n_primitives,
+        grid.x,
+        grid.y,
+        active_sh_bases,
+        total_bases_sh_rest,
+        static_cast<float>(width),
+        static_cast<float>(height),
+        fx,
+        fy,
+        cx,
+        cy,
+        near,
+        far
+    );
+    CHECK_CUDA(config::debug, "preprocess")
+
+    int n_visible_primitives;
+    cudaMemcpy(&n_visible_primitives, per_primitive_buffers.n_visible_primitives, sizeof(uint), cudaMemcpyDeviceToHost);
+    int n_instances;
+    cudaMemcpy(&n_instances, per_primitive_buffers.n_instances, sizeof(uint), cudaMemcpyDeviceToHost);
+
+    cub::DeviceRadixSort::SortPairs(
+        per_primitive_buffers.cub_workspace,
+        per_primitive_buffers.cub_workspace_size,
+        per_primitive_buffers.depth_keys,
+        per_primitive_buffers.primitive_indices,
+        n_visible_primitives
+    );
+    CHECK_CUDA(config::debug, "cub::DeviceRadixSort::SortPairs (Depth)")
+
+    kernels::forward::apply_depth_ordering_cu<<<div_round_up(n_visible_primitives, config::block_size_apply_depth_ordering), config::block_size_apply_depth_ordering>>>(
+        per_primitive_buffers.primitive_indices.Current(),
+        per_primitive_buffers.n_touched_tiles,
+        per_primitive_buffers.offset,
+        n_visible_primitives
+    );
+    CHECK_CUDA(config::debug, "apply_depth_ordering")
+
+    cub::DeviceScan::ExclusiveSum(
+        per_primitive_buffers.cub_workspace,
+        per_primitive_buffers.cub_workspace_size,
+        per_primitive_buffers.offset,
+        per_primitive_buffers.offset,
+        n_visible_primitives
+    );
+    CHECK_CUDA(config::debug, "cub::DeviceScan::ExclusiveSum (Primitive Offsets)")
+
+    char* per_instance_buffers_blob = per_instance_buffers_func(required<PerInstanceBuffers>(n_instances));
+    PerInstanceBuffers per_instance_buffers = PerInstanceBuffers::from_blob(per_instance_buffers_blob, n_instances);
+
+    kernels::forward::create_instances_cu<<<div_round_up(n_visible_primitives, config::block_size_create_instances), config::block_size_create_instances>>>(
+        per_primitive_buffers.primitive_indices.Current(),
+        per_primitive_buffers.offset,
+        per_primitive_buffers.screen_bounds,
+        per_primitive_buffers.mean2d,
+        per_primitive_buffers.conic_opacity,
+        per_instance_buffers.keys.Current(),
+        per_instance_buffers.primitive_indices.Current(),
+        grid.x,
+        n_visible_primitives
+    );
+    CHECK_CUDA(config::debug, "create_instances")
+
+    cub::DeviceRadixSort::SortPairs(
+        per_instance_buffers.cub_workspace,
+        per_instance_buffers.cub_workspace_size,
+        per_instance_buffers.keys,
+        per_instance_buffers.primitive_indices,
+        n_instances
+    );
+    CHECK_CUDA(config::debug, "cub::DeviceRadixSort::SortPairs (Tile)")
+
+    if constexpr (!config::debug) cudaStreamSynchronize(memset_stream);
+
+    if (n_instances > 0) {
+        kernels::forward::extract_instance_ranges_cu<<<div_round_up(n_instances, config::block_size_extract_instance_ranges), config::block_size_extract_instance_ranges>>>(
+            per_instance_buffers.keys.Current(),
+            per_tile_buffers.instance_ranges,
+            n_instances
+        );
+        CHECK_CUDA(config::debug, "extract_instance_ranges")
+    }
+
+    kernels::forward::extract_bucket_counts<<<div_round_up(n_tiles, config::block_size_extract_bucket_counts), config::block_size_extract_bucket_counts>>>(
+        per_tile_buffers.instance_ranges,
+        per_tile_buffers.n_buckets,
+        n_tiles
+    );
+    CHECK_CUDA(config::debug, "extract_bucket_counts")
+
+    cub::DeviceScan::InclusiveSum(
+        per_tile_buffers.cub_workspace,
+        per_tile_buffers.cub_workspace_size,
+        per_tile_buffers.n_buckets,
+        per_tile_buffers.bucket_offsets,
+        n_tiles);
+    CHECK_CUDA(config::debug, "cub::DeviceScan::InclusiveSum (Bucket Counts)")
+
+    int n_buckets;
+    cudaMemcpy(&n_buckets, per_tile_buffers.bucket_offsets + n_tiles - 1, sizeof(uint), cudaMemcpyDeviceToHost);
+
+    char* per_bucket_buffers_blob = per_bucket_buffers_func(required<PerBucketBuffers>(n_buckets));
+    PerBucketBuffers per_bucket_buffers = PerBucketBuffers::from_blob(per_bucket_buffers_blob, n_buckets);
+
+    kernels::forward::blend_cu<<<grid, block>>>(
+        per_tile_buffers.instance_ranges,
+        per_tile_buffers.bucket_offsets,
+        per_instance_buffers.primitive_indices.Current(),
+        per_primitive_buffers.mean2d,
+        per_primitive_buffers.conic_opacity,
+        per_primitive_buffers.color,
+        bg_color,
+        image,
+        per_tile_buffers.final_transmittances,
+        per_tile_buffers.max_n_contributions,
+        per_tile_buffers.n_contributions,
+        per_bucket_buffers.tile_index,
+        per_bucket_buffers.color_transmittance,
+        width,
+        height,
+        grid.x
+    );
+    CHECK_CUDA(config::debug, "blend")
+
+    return {n_visible_primitives, n_instances, n_buckets, per_primitive_buffers.primitive_indices.selector, per_instance_buffers.primitive_indices.selector};
+
+}

--- a/fastgs/rasterization/src/rasterization_api.cu
+++ b/fastgs/rasterization/src/rasterization_api.cu
@@ -1,0 +1,175 @@
+#include "rasterization_api.h"
+#include "forward.h"
+#include "backward.h"
+#include "torch_utils.h"
+#include "rasterization_config.h"
+#include "helper_math.h"
+#include <stdexcept>
+#include <functional>
+#include <tuple>
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, int, int, int, int, int>
+fast_gs::rasterization::forward_wrapper(
+    const torch::Tensor& means,
+    const torch::Tensor& scales_raw,
+    const torch::Tensor& rotations_raw,
+    const torch::Tensor& opacities_raw,
+    const torch::Tensor& sh_coefficients_0,
+    const torch::Tensor& sh_coefficients_rest,
+    const torch::Tensor& w2c,
+    const torch::Tensor& cam_position,
+    const torch::Tensor& bg_color,
+    const int active_sh_bases,
+    const int width,
+    const int height,
+    const float focal_x,
+    const float focal_y,
+    const float center_x,
+    const float center_y,
+    const float near_plane,
+    const float far_plane)
+{
+    // all optimizable tensors must be contiguous CUDA float tensors
+    CHECK_INPUT(config::debug, means, "means");
+    CHECK_INPUT(config::debug, scales_raw, "scales_raw");
+    CHECK_INPUT(config::debug, rotations_raw, "rotations_raw");
+    CHECK_INPUT(config::debug, opacities_raw, "opacities_raw");
+    CHECK_INPUT(config::debug, sh_coefficients_0, "sh_coefficients_0");
+    CHECK_INPUT(config::debug, sh_coefficients_rest, "sh_coefficients_rest");
+
+    const int n_primitives = means.size(0);
+    const int total_bases_sh_rest = sh_coefficients_rest.size(1);
+    const torch::TensorOptions float_options = torch::TensorOptions().dtype(torch::kFloat).device(torch::kCUDA);
+    const torch::TensorOptions byte_options = torch::TensorOptions().dtype(torch::kByte).device(torch::kCUDA);
+    torch::Tensor image = torch::empty({3, height, width}, float_options);
+    torch::Tensor per_primitive_buffers = torch::empty({0}, byte_options);
+    torch::Tensor per_tile_buffers = torch::empty({0}, byte_options);
+    torch::Tensor per_instance_buffers = torch::empty({0}, byte_options);
+    torch::Tensor per_bucket_buffers = torch::empty({0}, byte_options);
+    const std::function<char*(size_t)> per_primitive_buffers_func = resize_function_wrapper(per_primitive_buffers);
+    const std::function<char*(size_t)> per_tile_buffers_func = resize_function_wrapper(per_tile_buffers);
+    const std::function<char*(size_t)> per_instance_buffers_func = resize_function_wrapper(per_instance_buffers);
+    const std::function<char*(size_t)> per_bucket_buffers_func = resize_function_wrapper(per_bucket_buffers);
+
+    auto [n_visible_primitives, n_instances, n_buckets, primitive_primitive_indices_selector, instance_primitive_indices_selector] = forward(
+        per_primitive_buffers_func,
+        per_tile_buffers_func,
+        per_instance_buffers_func,
+        per_bucket_buffers_func,
+        reinterpret_cast<float3*>(means.data_ptr<float>()),
+        reinterpret_cast<float3*>(scales_raw.data_ptr<float>()),
+        reinterpret_cast<float4*>(rotations_raw.data_ptr<float>()),
+        opacities_raw.data_ptr<float>(),
+        reinterpret_cast<float3*>(sh_coefficients_0.data_ptr<float>()),
+        reinterpret_cast<float3*>(sh_coefficients_rest.data_ptr<float>()),
+        reinterpret_cast<float4*>(w2c.contiguous().data_ptr<float>()),
+        reinterpret_cast<float3*>(cam_position.contiguous().data_ptr<float>()),
+        reinterpret_cast<float3*>(bg_color.contiguous().data_ptr<float>()),
+        image.data_ptr<float>(),
+        n_primitives,
+        active_sh_bases,
+        total_bases_sh_rest,
+        width,
+        height,
+        focal_x,
+        focal_y,
+        center_x,
+        center_y,
+        near_plane,
+        far_plane
+    );
+    
+    return {
+        image,
+        per_primitive_buffers, per_tile_buffers, per_instance_buffers, per_bucket_buffers,
+        n_visible_primitives, n_instances, n_buckets,
+        primitive_primitive_indices_selector, instance_primitive_indices_selector
+    };
+}
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+fast_gs::rasterization::backward_wrapper(
+    torch::Tensor& densification_info,
+    const torch::Tensor& grad_image,
+    const torch::Tensor& image,
+    const torch::Tensor& means,
+    const torch::Tensor& scales_raw,
+    const torch::Tensor& rotations_raw,
+    const torch::Tensor& sh_coefficients_rest,
+    const torch::Tensor& per_primitive_buffers,
+    const torch::Tensor& per_tile_buffers,
+    const torch::Tensor& per_instance_buffers,
+    const torch::Tensor& per_bucket_buffers,
+    const torch::Tensor& w2c,
+    const torch::Tensor& cam_position,
+    const torch::Tensor& bg_color,
+    const int active_sh_bases,
+    const int width,
+    const int height,
+    const float focal_x,
+    const float focal_y,
+    const float center_x,
+    const float center_y,
+    const float near_plane,
+    const float far_plane,
+    const int n_visible_primitives,
+    const int n_instances,
+    const int n_buckets,
+    const int primitive_primitive_indices_selector,
+    const int instance_primitive_indices_selector)
+{
+    const int n_primitives = means.size(0);
+    const int total_bases_sh_rest = sh_coefficients_rest.size(1);
+    const torch::TensorOptions float_options = torch::TensorOptions().dtype(torch::kFloat).device(torch::kCUDA);
+    torch::Tensor grad_means = torch::zeros({n_primitives, 3}, float_options);
+    torch::Tensor grad_scales_raw = torch::zeros({n_primitives, 3}, float_options);
+    torch::Tensor grad_rotations_raw = torch::zeros({n_primitives, 4}, float_options);
+    torch::Tensor grad_opacities_raw = torch::zeros({n_primitives, 1}, float_options);
+    torch::Tensor grad_sh_coefficients_0 = torch::zeros({n_primitives, 1, 3}, float_options);
+    torch::Tensor grad_sh_coefficients_rest = torch::zeros({n_primitives, total_bases_sh_rest, 3}, float_options);
+    torch::Tensor grad_mean2d_helper = torch::zeros({n_primitives, 2}, float_options);
+    torch::Tensor grad_conic_helper = torch::zeros({n_primitives, 3}, float_options);
+
+    const bool update_densification_info = densification_info.size(0) > 0;
+
+    backward(
+        grad_image.data_ptr<float>(),
+        image.data_ptr<float>(),
+        reinterpret_cast<float3*>(means.data_ptr<float>()),
+        reinterpret_cast<float3*>(scales_raw.data_ptr<float>()),
+        reinterpret_cast<float4*>(rotations_raw.data_ptr<float>()),
+        reinterpret_cast<float3*>(sh_coefficients_rest.data_ptr<float>()),
+        reinterpret_cast<float4*>(w2c.contiguous().data_ptr<float>()),
+        reinterpret_cast<float3*>(cam_position.contiguous().data_ptr<float>()),
+        reinterpret_cast<float3*>(bg_color.contiguous().data_ptr<float>()),
+        reinterpret_cast<char*>(per_primitive_buffers.data_ptr()),
+        reinterpret_cast<char*>(per_tile_buffers.data_ptr()),
+        reinterpret_cast<char*>(per_instance_buffers.data_ptr()),
+        reinterpret_cast<char*>(per_bucket_buffers.data_ptr()),
+        reinterpret_cast<float3*>(grad_means.data_ptr<float>()),
+        reinterpret_cast<float3*>(grad_scales_raw.data_ptr<float>()),
+        reinterpret_cast<float4*>(grad_rotations_raw.data_ptr<float>()),
+        reinterpret_cast<float*>(grad_opacities_raw.data_ptr<float>()),
+        reinterpret_cast<float3*>(grad_sh_coefficients_0.data_ptr<float>()),
+        reinterpret_cast<float3*>(grad_sh_coefficients_rest.data_ptr<float>()),
+        reinterpret_cast<float2*>(grad_mean2d_helper.data_ptr<float>()),
+        grad_conic_helper.data_ptr<float>(),
+        update_densification_info ? densification_info.data_ptr<float>() : nullptr,
+        n_primitives,
+        n_visible_primitives,
+        n_instances,
+        n_buckets,
+        primitive_primitive_indices_selector,
+        instance_primitive_indices_selector,
+        active_sh_bases,
+        total_bases_sh_rest,
+        width,
+        height,
+        focal_x,
+        focal_y,
+        center_x,
+        center_y
+    );
+
+    return {grad_means, grad_scales_raw, grad_rotations_raw, grad_opacities_raw, grad_sh_coefficients_0, grad_sh_coefficients_rest};
+}

--- a/fastgs/utils/helper_math.h
+++ b/fastgs/utils/helper_math.h
@@ -1,0 +1,1560 @@
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ *  This file implements common mathematical operations on vector types
+ *  (float3, float4 etc.) since these are not provided as standard by CUDA.
+ *
+ *  The syntax is modeled on the Cg standard library.
+ *
+ *  This is part of the Helper library includes
+ *
+ *    Thanks to Linh Hah for additions and fixes.
+ */
+
+/*
+ * This version includes multiple additions by Florian Hahlbohm.
+ */
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+typedef unsigned int uint;
+typedef unsigned short ushort;
+
+#ifndef EXIT_WAIVED
+#define EXIT_WAIVED 2
+#endif
+
+#ifndef __CUDACC__
+#include <math.h>
+
+////////////////////////////////////////////////////////////////////////////////
+// host implementations of CUDA functions
+////////////////////////////////////////////////////////////////////////////////
+
+inline float fminf(float a, float b)
+{
+    return a < b ? a : b;
+}
+
+inline float fmaxf(float a, float b)
+{
+    return a > b ? a : b;
+}
+
+inline int max(int a, int b)
+{
+    return a > b ? a : b;
+}
+
+inline int min(int a, int b)
+{
+    return a < b ? a : b;
+}
+
+inline float rsqrtf(float x)
+{
+    return 1.0f / sqrtf(x);
+}
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+// constructors
+////////////////////////////////////////////////////////////////////////////////
+
+inline __host__ __device__ float2 make_float2(float s)
+{
+    return make_float2(s, s);
+}
+inline __host__ __device__ float2 make_float2(float3 a)
+{
+    return make_float2(a.x, a.y);
+}
+inline __host__ __device__ float2 make_float2(int2 a)
+{
+    return make_float2(float(a.x), float(a.y));
+}
+inline __host__ __device__ float2 make_float2(uint2 a)
+{
+    return make_float2(float(a.x), float(a.y));
+}
+
+inline __host__ __device__ int2 make_int2(int s)
+{
+    return make_int2(s, s);
+}
+inline __host__ __device__ int2 make_int2(int3 a)
+{
+    return make_int2(a.x, a.y);
+}
+inline __host__ __device__ int2 make_int2(uint2 a)
+{
+    return make_int2(int(a.x), int(a.y));
+}
+inline __host__ __device__ int2 make_int2(float2 a)
+{
+    return make_int2(int(a.x), int(a.y));
+}
+
+inline __host__ __device__ uint2 make_uint2(uint s)
+{
+    return make_uint2(s, s);
+}
+inline __host__ __device__ uint2 make_uint2(uint3 a)
+{
+    return make_uint2(a.x, a.y);
+}
+inline __host__ __device__ uint2 make_uint2(int2 a)
+{
+    return make_uint2(uint(a.x), uint(a.y));
+}
+
+inline __host__ __device__ float3 make_float3(float s)
+{
+    return make_float3(s, s, s);
+}
+inline __host__ __device__ float3 make_float3(float2 a)
+{
+    return make_float3(a.x, a.y, 0.0f);
+}
+inline __host__ __device__ float3 make_float3(float2 a, float s)
+{
+    return make_float3(a.x, a.y, s);
+}
+inline __host__ __device__ float3 make_float3(float4 a)
+{
+    return make_float3(a.x, a.y, a.z);
+}
+inline __host__ __device__ float3 make_float3(int3 a)
+{
+    return make_float3(float(a.x), float(a.y), float(a.z));
+}
+inline __host__ __device__ float3 make_float3(uint3 a)
+{
+    return make_float3(float(a.x), float(a.y), float(a.z));
+}
+
+inline __host__ __device__ int3 make_int3(int s)
+{
+    return make_int3(s, s, s);
+}
+inline __host__ __device__ int3 make_int3(int2 a)
+{
+    return make_int3(a.x, a.y, 0);
+}
+inline __host__ __device__ int3 make_int3(int2 a, int s)
+{
+    return make_int3(a.x, a.y, s);
+}
+inline __host__ __device__ int3 make_int3(uint3 a)
+{
+    return make_int3(int(a.x), int(a.y), int(a.z));
+}
+inline __host__ __device__ int3 make_int3(float3 a)
+{
+    return make_int3(int(a.x), int(a.y), int(a.z));
+}
+
+inline __host__ __device__ uint3 make_uint3(uint s)
+{
+    return make_uint3(s, s, s);
+}
+inline __host__ __device__ uint3 make_uint3(uint2 a)
+{
+    return make_uint3(a.x, a.y, 0);
+}
+inline __host__ __device__ uint3 make_uint3(uint2 a, uint s)
+{
+    return make_uint3(a.x, a.y, s);
+}
+inline __host__ __device__ uint3 make_uint3(uint4 a)
+{
+    return make_uint3(a.x, a.y, a.z);
+}
+inline __host__ __device__ uint3 make_uint3(int3 a)
+{
+    return make_uint3(uint(a.x), uint(a.y), uint(a.z));
+}
+
+inline __host__ __device__ float4 make_float4(float s)
+{
+    return make_float4(s, s, s, s);
+}
+inline __host__ __device__ float4 make_float4(float3 a)
+{
+    return make_float4(a.x, a.y, a.z, 0.0f);
+}
+inline __host__ __device__ float4 make_float4(float3 a, float w)
+{
+    return make_float4(a.x, a.y, a.z, w);
+}
+inline __host__ __device__ float4 make_float4(int4 a)
+{
+    return make_float4(float(a.x), float(a.y), float(a.z), float(a.w));
+}
+inline __host__ __device__ float4 make_float4(uint4 a)
+{
+    return make_float4(float(a.x), float(a.y), float(a.z), float(a.w));
+}
+
+inline __host__ __device__ int4 make_int4(int s)
+{
+    return make_int4(s, s, s, s);
+}
+inline __host__ __device__ int4 make_int4(int3 a)
+{
+    return make_int4(a.x, a.y, a.z, 0);
+}
+inline __host__ __device__ int4 make_int4(int3 a, int w)
+{
+    return make_int4(a.x, a.y, a.z, w);
+}
+inline __host__ __device__ int4 make_int4(uint4 a)
+{
+    return make_int4(int(a.x), int(a.y), int(a.z), int(a.w));
+}
+inline __host__ __device__ int4 make_int4(float4 a)
+{
+    return make_int4(int(a.x), int(a.y), int(a.z), int(a.w));
+}
+
+
+inline __host__ __device__ uint4 make_uint4(uint s)
+{
+    return make_uint4(s, s, s, s);
+}
+inline __host__ __device__ uint4 make_uint4(uint3 a)
+{
+    return make_uint4(a.x, a.y, a.z, 0);
+}
+inline __host__ __device__ uint4 make_uint4(uint3 a, uint w)
+{
+    return make_uint4(a.x, a.y, a.z, w);
+}
+inline __host__ __device__ uint4 make_uint4(int4 a)
+{
+    return make_uint4(uint(a.x), uint(a.y), uint(a.z), uint(a.w));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// negate
+////////////////////////////////////////////////////////////////////////////////
+
+inline __host__ __device__ float2 operator-(float2 &a)
+{
+    return make_float2(-a.x, -a.y);
+}
+inline __host__ __device__ int2 operator-(int2 &a)
+{
+    return make_int2(-a.x, -a.y);
+}
+inline __host__ __device__ float3 operator-(float3 &a)
+{
+    return make_float3(-a.x, -a.y, -a.z);
+}
+inline __host__ __device__ int3 operator-(int3 &a)
+{
+    return make_int3(-a.x, -a.y, -a.z);
+}
+inline __host__ __device__ float4 operator-(float4 &a)
+{
+    return make_float4(-a.x, -a.y, -a.z, -a.w);
+}
+inline __host__ __device__ int4 operator-(int4 &a)
+{
+    return make_int4(-a.x, -a.y, -a.z, -a.w);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// addition
+////////////////////////////////////////////////////////////////////////////////
+
+inline __host__ __device__ float2 operator+(float2 a, float2 b)
+{
+    return make_float2(a.x + b.x, a.y + b.y);
+}
+inline __host__ __device__ void operator+=(float2 &a, float2 b)
+{
+    a.x += b.x;
+    a.y += b.y;
+}
+inline __host__ __device__ float2 operator+(float2 a, float b)
+{
+    return make_float2(a.x + b, a.y + b);
+}
+inline __host__ __device__ float2 operator+(float b, float2 a)
+{
+    return make_float2(a.x + b, a.y + b);
+}
+inline __host__ __device__ void operator+=(float2 &a, float b)
+{
+    a.x += b;
+    a.y += b;
+}
+
+inline __host__ __device__ int2 operator+(int2 a, int2 b)
+{
+    return make_int2(a.x + b.x, a.y + b.y);
+}
+inline __host__ __device__ void operator+=(int2 &a, int2 b)
+{
+    a.x += b.x;
+    a.y += b.y;
+}
+inline __host__ __device__ int2 operator+(int2 a, int b)
+{
+    return make_int2(a.x + b, a.y + b);
+}
+inline __host__ __device__ int2 operator+(int b, int2 a)
+{
+    return make_int2(a.x + b, a.y + b);
+}
+inline __host__ __device__ void operator+=(int2 &a, int b)
+{
+    a.x += b;
+    a.y += b;
+}
+
+inline __host__ __device__ uint2 operator+(uint2 a, uint2 b)
+{
+    return make_uint2(a.x + b.x, a.y + b.y);
+}
+inline __host__ __device__ void operator+=(uint2 &a, uint2 b)
+{
+    a.x += b.x;
+    a.y += b.y;
+}
+inline __host__ __device__ uint2 operator+(uint2 a, uint b)
+{
+    return make_uint2(a.x + b, a.y + b);
+}
+inline __host__ __device__ uint2 operator+(uint b, uint2 a)
+{
+    return make_uint2(a.x + b, a.y + b);
+}
+inline __host__ __device__ void operator+=(uint2 &a, uint b)
+{
+    a.x += b;
+    a.y += b;
+}
+
+
+inline __host__ __device__ float3 operator+(float3 a, float3 b)
+{
+    return make_float3(a.x + b.x, a.y + b.y, a.z + b.z);
+}
+inline __host__ __device__ void operator+=(float3 &a, float3 b)
+{
+    a.x += b.x;
+    a.y += b.y;
+    a.z += b.z;
+}
+inline __host__ __device__ float3 operator+(float3 a, float b)
+{
+    return make_float3(a.x + b, a.y + b, a.z + b);
+}
+inline __host__ __device__ void operator+=(float3 &a, float b)
+{
+    a.x += b;
+    a.y += b;
+    a.z += b;
+}
+
+inline __host__ __device__ int3 operator+(int3 a, int3 b)
+{
+    return make_int3(a.x + b.x, a.y + b.y, a.z + b.z);
+}
+inline __host__ __device__ void operator+=(int3 &a, int3 b)
+{
+    a.x += b.x;
+    a.y += b.y;
+    a.z += b.z;
+}
+inline __host__ __device__ int3 operator+(int3 a, int b)
+{
+    return make_int3(a.x + b, a.y + b, a.z + b);
+}
+inline __host__ __device__ void operator+=(int3 &a, int b)
+{
+    a.x += b;
+    a.y += b;
+    a.z += b;
+}
+
+inline __host__ __device__ uint3 operator+(uint3 a, uint3 b)
+{
+    return make_uint3(a.x + b.x, a.y + b.y, a.z + b.z);
+}
+inline __host__ __device__ void operator+=(uint3 &a, uint3 b)
+{
+    a.x += b.x;
+    a.y += b.y;
+    a.z += b.z;
+}
+inline __host__ __device__ uint3 operator+(uint3 a, uint b)
+{
+    return make_uint3(a.x + b, a.y + b, a.z + b);
+}
+inline __host__ __device__ void operator+=(uint3 &a, uint b)
+{
+    a.x += b;
+    a.y += b;
+    a.z += b;
+}
+
+inline __host__ __device__ int3 operator+(int b, int3 a)
+{
+    return make_int3(a.x + b, a.y + b, a.z + b);
+}
+inline __host__ __device__ uint3 operator+(uint b, uint3 a)
+{
+    return make_uint3(a.x + b, a.y + b, a.z + b);
+}
+inline __host__ __device__ float3 operator+(float b, float3 a)
+{
+    return make_float3(a.x + b, a.y + b, a.z + b);
+}
+
+inline __host__ __device__ float4 operator+(float4 a, float4 b)
+{
+    return make_float4(a.x + b.x, a.y + b.y, a.z + b.z,  a.w + b.w);
+}
+inline __host__ __device__ void operator+=(float4 &a, float4 b)
+{
+    a.x += b.x;
+    a.y += b.y;
+    a.z += b.z;
+    a.w += b.w;
+}
+inline __host__ __device__ float4 operator+(float4 a, float b)
+{
+    return make_float4(a.x + b, a.y + b, a.z + b, a.w + b);
+}
+inline __host__ __device__ float4 operator+(float b, float4 a)
+{
+    return make_float4(a.x + b, a.y + b, a.z + b, a.w + b);
+}
+inline __host__ __device__ void operator+=(float4 &a, float b)
+{
+    a.x += b;
+    a.y += b;
+    a.z += b;
+    a.w += b;
+}
+
+inline __host__ __device__ int4 operator+(int4 a, int4 b)
+{
+    return make_int4(a.x + b.x, a.y + b.y, a.z + b.z,  a.w + b.w);
+}
+inline __host__ __device__ void operator+=(int4 &a, int4 b)
+{
+    a.x += b.x;
+    a.y += b.y;
+    a.z += b.z;
+    a.w += b.w;
+}
+inline __host__ __device__ int4 operator+(int4 a, int b)
+{
+    return make_int4(a.x + b, a.y + b, a.z + b,  a.w + b);
+}
+inline __host__ __device__ int4 operator+(int b, int4 a)
+{
+    return make_int4(a.x + b, a.y + b, a.z + b,  a.w + b);
+}
+inline __host__ __device__ void operator+=(int4 &a, int b)
+{
+    a.x += b;
+    a.y += b;
+    a.z += b;
+    a.w += b;
+}
+
+inline __host__ __device__ uint4 operator+(uint4 a, uint4 b)
+{
+    return make_uint4(a.x + b.x, a.y + b.y, a.z + b.z,  a.w + b.w);
+}
+inline __host__ __device__ void operator+=(uint4 &a, uint4 b)
+{
+    a.x += b.x;
+    a.y += b.y;
+    a.z += b.z;
+    a.w += b.w;
+}
+inline __host__ __device__ uint4 operator+(uint4 a, uint b)
+{
+    return make_uint4(a.x + b, a.y + b, a.z + b,  a.w + b);
+}
+inline __host__ __device__ uint4 operator+(uint b, uint4 a)
+{
+    return make_uint4(a.x + b, a.y + b, a.z + b,  a.w + b);
+}
+inline __host__ __device__ void operator+=(uint4 &a, uint b)
+{
+    a.x += b;
+    a.y += b;
+    a.z += b;
+    a.w += b;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// subtract
+////////////////////////////////////////////////////////////////////////////////
+
+inline __host__ __device__ float2 operator-(float2 a, float2 b)
+{
+    return make_float2(a.x - b.x, a.y - b.y);
+}
+inline __host__ __device__ void operator-=(float2 &a, float2 b)
+{
+    a.x -= b.x;
+    a.y -= b.y;
+}
+inline __host__ __device__ float2 operator-(float2 a, float b)
+{
+    return make_float2(a.x - b, a.y - b);
+}
+inline __host__ __device__ float2 operator-(float b, float2 a)
+{
+    return make_float2(b - a.x, b - a.y);
+}
+inline __host__ __device__ void operator-=(float2 &a, float b)
+{
+    a.x -= b;
+    a.y -= b;
+}
+
+inline __host__ __device__ int2 operator-(int2 a, int2 b)
+{
+    return make_int2(a.x - b.x, a.y - b.y);
+}
+inline __host__ __device__ void operator-=(int2 &a, int2 b)
+{
+    a.x -= b.x;
+    a.y -= b.y;
+}
+inline __host__ __device__ int2 operator-(int2 a, int b)
+{
+    return make_int2(a.x - b, a.y - b);
+}
+inline __host__ __device__ int2 operator-(int b, int2 a)
+{
+    return make_int2(b - a.x, b - a.y);
+}
+inline __host__ __device__ void operator-=(int2 &a, int b)
+{
+    a.x -= b;
+    a.y -= b;
+}
+
+inline __host__ __device__ uint2 operator-(uint2 a, uint2 b)
+{
+    return make_uint2(a.x - b.x, a.y - b.y);
+}
+inline __host__ __device__ void operator-=(uint2 &a, uint2 b)
+{
+    a.x -= b.x;
+    a.y -= b.y;
+}
+inline __host__ __device__ uint2 operator-(uint2 a, uint b)
+{
+    return make_uint2(a.x - b, a.y - b);
+}
+inline __host__ __device__ uint2 operator-(uint b, uint2 a)
+{
+    return make_uint2(b - a.x, b - a.y);
+}
+inline __host__ __device__ void operator-=(uint2 &a, uint b)
+{
+    a.x -= b;
+    a.y -= b;
+}
+
+inline __host__ __device__ float3 operator-(float3 a, float3 b)
+{
+    return make_float3(a.x - b.x, a.y - b.y, a.z - b.z);
+}
+inline __host__ __device__ void operator-=(float3 &a, float3 b)
+{
+    a.x -= b.x;
+    a.y -= b.y;
+    a.z -= b.z;
+}
+inline __host__ __device__ float3 operator-(float3 a, float b)
+{
+    return make_float3(a.x - b, a.y - b, a.z - b);
+}
+inline __host__ __device__ float3 operator-(float b, float3 a)
+{
+    return make_float3(b - a.x, b - a.y, b - a.z);
+}
+inline __host__ __device__ void operator-=(float3 &a, float b)
+{
+    a.x -= b;
+    a.y -= b;
+    a.z -= b;
+}
+
+inline __host__ __device__ int3 operator-(int3 a, int3 b)
+{
+    return make_int3(a.x - b.x, a.y - b.y, a.z - b.z);
+}
+inline __host__ __device__ void operator-=(int3 &a, int3 b)
+{
+    a.x -= b.x;
+    a.y -= b.y;
+    a.z -= b.z;
+}
+inline __host__ __device__ int3 operator-(int3 a, int b)
+{
+    return make_int3(a.x - b, a.y - b, a.z - b);
+}
+inline __host__ __device__ int3 operator-(int b, int3 a)
+{
+    return make_int3(b - a.x, b - a.y, b - a.z);
+}
+inline __host__ __device__ void operator-=(int3 &a, int b)
+{
+    a.x -= b;
+    a.y -= b;
+    a.z -= b;
+}
+
+inline __host__ __device__ uint3 operator-(uint3 a, uint3 b)
+{
+    return make_uint3(a.x - b.x, a.y - b.y, a.z - b.z);
+}
+inline __host__ __device__ void operator-=(uint3 &a, uint3 b)
+{
+    a.x -= b.x;
+    a.y -= b.y;
+    a.z -= b.z;
+}
+inline __host__ __device__ uint3 operator-(uint3 a, uint b)
+{
+    return make_uint3(a.x - b, a.y - b, a.z - b);
+}
+inline __host__ __device__ uint3 operator-(uint b, uint3 a)
+{
+    return make_uint3(b - a.x, b - a.y, b - a.z);
+}
+inline __host__ __device__ void operator-=(uint3 &a, uint b)
+{
+    a.x -= b;
+    a.y -= b;
+    a.z -= b;
+}
+
+inline __host__ __device__ float4 operator-(float4 a, float4 b)
+{
+    return make_float4(a.x - b.x, a.y - b.y, a.z - b.z,  a.w - b.w);
+}
+inline __host__ __device__ void operator-=(float4 &a, float4 b)
+{
+    a.x -= b.x;
+    a.y -= b.y;
+    a.z -= b.z;
+    a.w -= b.w;
+}
+inline __host__ __device__ float4 operator-(float4 a, float b)
+{
+    return make_float4(a.x - b, a.y - b, a.z - b,  a.w - b);
+}
+inline __host__ __device__ void operator-=(float4 &a, float b)
+{
+    a.x -= b;
+    a.y -= b;
+    a.z -= b;
+    a.w -= b;
+}
+
+inline __host__ __device__ int4 operator-(int4 a, int4 b)
+{
+    return make_int4(a.x - b.x, a.y - b.y, a.z - b.z,  a.w - b.w);
+}
+inline __host__ __device__ void operator-=(int4 &a, int4 b)
+{
+    a.x -= b.x;
+    a.y -= b.y;
+    a.z -= b.z;
+    a.w -= b.w;
+}
+inline __host__ __device__ int4 operator-(int4 a, int b)
+{
+    return make_int4(a.x - b, a.y - b, a.z - b,  a.w - b);
+}
+inline __host__ __device__ int4 operator-(int b, int4 a)
+{
+    return make_int4(b - a.x, b - a.y, b - a.z, b - a.w);
+}
+inline __host__ __device__ void operator-=(int4 &a, int b)
+{
+    a.x -= b;
+    a.y -= b;
+    a.z -= b;
+    a.w -= b;
+}
+
+inline __host__ __device__ uint4 operator-(uint4 a, uint4 b)
+{
+    return make_uint4(a.x - b.x, a.y - b.y, a.z - b.z,  a.w - b.w);
+}
+inline __host__ __device__ void operator-=(uint4 &a, uint4 b)
+{
+    a.x -= b.x;
+    a.y -= b.y;
+    a.z -= b.z;
+    a.w -= b.w;
+}
+inline __host__ __device__ uint4 operator-(uint4 a, uint b)
+{
+    return make_uint4(a.x - b, a.y - b, a.z - b,  a.w - b);
+}
+inline __host__ __device__ uint4 operator-(uint b, uint4 a)
+{
+    return make_uint4(b - a.x, b - a.y, b - a.z, b - a.w);
+}
+inline __host__ __device__ void operator-=(uint4 &a, uint b)
+{
+    a.x -= b;
+    a.y -= b;
+    a.z -= b;
+    a.w -= b;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// multiply
+////////////////////////////////////////////////////////////////////////////////
+
+inline __host__ __device__ float2 operator*(float2 a, float2 b)
+{
+    return make_float2(a.x * b.x, a.y * b.y);
+}
+inline __host__ __device__ void operator*=(float2 &a, float2 b)
+{
+    a.x *= b.x;
+    a.y *= b.y;
+}
+inline __host__ __device__ float2 operator*(float2 a, float b)
+{
+    return make_float2(a.x * b, a.y * b);
+}
+inline __host__ __device__ float2 operator*(float b, float2 a)
+{
+    return make_float2(b * a.x, b * a.y);
+}
+inline __host__ __device__ void operator*=(float2 &a, float b)
+{
+    a.x *= b;
+    a.y *= b;
+}
+
+inline __host__ __device__ int2 operator*(int2 a, int2 b)
+{
+    return make_int2(a.x * b.x, a.y * b.y);
+}
+inline __host__ __device__ void operator*=(int2 &a, int2 b)
+{
+    a.x *= b.x;
+    a.y *= b.y;
+}
+inline __host__ __device__ int2 operator*(int2 a, int b)
+{
+    return make_int2(a.x * b, a.y * b);
+}
+inline __host__ __device__ int2 operator*(int b, int2 a)
+{
+    return make_int2(b * a.x, b * a.y);
+}
+inline __host__ __device__ void operator*=(int2 &a, int b)
+{
+    a.x *= b;
+    a.y *= b;
+}
+
+inline __host__ __device__ uint2 operator*(uint2 a, uint2 b)
+{
+    return make_uint2(a.x * b.x, a.y * b.y);
+}
+inline __host__ __device__ void operator*=(uint2 &a, uint2 b)
+{
+    a.x *= b.x;
+    a.y *= b.y;
+}
+inline __host__ __device__ uint2 operator*(uint2 a, uint b)
+{
+    return make_uint2(a.x * b, a.y * b);
+}
+inline __host__ __device__ uint2 operator*(uint b, uint2 a)
+{
+    return make_uint2(b * a.x, b * a.y);
+}
+inline __host__ __device__ void operator*=(uint2 &a, uint b)
+{
+    a.x *= b;
+    a.y *= b;
+}
+
+inline __host__ __device__ float3 operator*(float3 a, float3 b)
+{
+    return make_float3(a.x * b.x, a.y * b.y, a.z * b.z);
+}
+inline __host__ __device__ void operator*=(float3 &a, float3 b)
+{
+    a.x *= b.x;
+    a.y *= b.y;
+    a.z *= b.z;
+}
+inline __host__ __device__ float3 operator*(float3 a, float b)
+{
+    return make_float3(a.x * b, a.y * b, a.z * b);
+}
+inline __host__ __device__ float3 operator*(float b, float3 a)
+{
+    return make_float3(b * a.x, b * a.y, b * a.z);
+}
+inline __host__ __device__ void operator*=(float3 &a, float b)
+{
+    a.x *= b;
+    a.y *= b;
+    a.z *= b;
+}
+
+inline __host__ __device__ int3 operator*(int3 a, int3 b)
+{
+    return make_int3(a.x * b.x, a.y * b.y, a.z * b.z);
+}
+inline __host__ __device__ void operator*=(int3 &a, int3 b)
+{
+    a.x *= b.x;
+    a.y *= b.y;
+    a.z *= b.z;
+}
+inline __host__ __device__ int3 operator*(int3 a, int b)
+{
+    return make_int3(a.x * b, a.y * b, a.z * b);
+}
+inline __host__ __device__ int3 operator*(int b, int3 a)
+{
+    return make_int3(b * a.x, b * a.y, b * a.z);
+}
+inline __host__ __device__ void operator*=(int3 &a, int b)
+{
+    a.x *= b;
+    a.y *= b;
+    a.z *= b;
+}
+
+inline __host__ __device__ uint3 operator*(uint3 a, uint3 b)
+{
+    return make_uint3(a.x * b.x, a.y * b.y, a.z * b.z);
+}
+inline __host__ __device__ void operator*=(uint3 &a, uint3 b)
+{
+    a.x *= b.x;
+    a.y *= b.y;
+    a.z *= b.z;
+}
+inline __host__ __device__ uint3 operator*(uint3 a, uint b)
+{
+    return make_uint3(a.x * b, a.y * b, a.z * b);
+}
+inline __host__ __device__ uint3 operator*(uint b, uint3 a)
+{
+    return make_uint3(b * a.x, b * a.y, b * a.z);
+}
+inline __host__ __device__ void operator*=(uint3 &a, uint b)
+{
+    a.x *= b;
+    a.y *= b;
+    a.z *= b;
+}
+
+inline __host__ __device__ float4 operator*(float4 a, float4 b)
+{
+    return make_float4(a.x * b.x, a.y * b.y, a.z * b.z,  a.w * b.w);
+}
+inline __host__ __device__ void operator*=(float4 &a, float4 b)
+{
+    a.x *= b.x;
+    a.y *= b.y;
+    a.z *= b.z;
+    a.w *= b.w;
+}
+inline __host__ __device__ float4 operator*(float4 a, float b)
+{
+    return make_float4(a.x * b, a.y * b, a.z * b,  a.w * b);
+}
+inline __host__ __device__ float4 operator*(float b, float4 a)
+{
+    return make_float4(b * a.x, b * a.y, b * a.z, b * a.w);
+}
+inline __host__ __device__ void operator*=(float4 &a, float b)
+{
+    a.x *= b;
+    a.y *= b;
+    a.z *= b;
+    a.w *= b;
+}
+
+inline __host__ __device__ int4 operator*(int4 a, int4 b)
+{
+    return make_int4(a.x * b.x, a.y * b.y, a.z * b.z,  a.w * b.w);
+}
+inline __host__ __device__ void operator*=(int4 &a, int4 b)
+{
+    a.x *= b.x;
+    a.y *= b.y;
+    a.z *= b.z;
+    a.w *= b.w;
+}
+inline __host__ __device__ int4 operator*(int4 a, int b)
+{
+    return make_int4(a.x * b, a.y * b, a.z * b,  a.w * b);
+}
+inline __host__ __device__ int4 operator*(int b, int4 a)
+{
+    return make_int4(b * a.x, b * a.y, b * a.z, b * a.w);
+}
+inline __host__ __device__ void operator*=(int4 &a, int b)
+{
+    a.x *= b;
+    a.y *= b;
+    a.z *= b;
+    a.w *= b;
+}
+
+inline __host__ __device__ uint4 operator*(uint4 a, uint4 b)
+{
+    return make_uint4(a.x * b.x, a.y * b.y, a.z * b.z,  a.w * b.w);
+}
+inline __host__ __device__ void operator*=(uint4 &a, uint4 b)
+{
+    a.x *= b.x;
+    a.y *= b.y;
+    a.z *= b.z;
+    a.w *= b.w;
+}
+inline __host__ __device__ uint4 operator*(uint4 a, uint b)
+{
+    return make_uint4(a.x * b, a.y * b, a.z * b,  a.w * b);
+}
+inline __host__ __device__ uint4 operator*(uint b, uint4 a)
+{
+    return make_uint4(b * a.x, b * a.y, b * a.z, b * a.w);
+}
+inline __host__ __device__ void operator*=(uint4 &a, uint b)
+{
+    a.x *= b;
+    a.y *= b;
+    a.z *= b;
+    a.w *= b;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// divide
+////////////////////////////////////////////////////////////////////////////////
+
+inline __host__ __device__ float2 operator/(float2 a, float2 b)
+{
+    return make_float2(a.x / b.x, a.y / b.y);
+}
+inline __host__ __device__ void operator/=(float2 &a, float2 b)
+{
+    a.x /= b.x;
+    a.y /= b.y;
+}
+inline __host__ __device__ float2 operator/(float2 a, float b)
+{
+    return make_float2(a.x / b, a.y / b);
+}
+inline __host__ __device__ void operator/=(float2 &a, float b)
+{
+    a.x /= b;
+    a.y /= b;
+}
+inline __host__ __device__ float2 operator/(float b, float2 a)
+{
+    return make_float2(b / a.x, b / a.y);
+}
+
+inline __host__ __device__ float3 operator/(float3 a, float3 b)
+{
+    return make_float3(a.x / b.x, a.y / b.y, a.z / b.z);
+}
+inline __host__ __device__ void operator/=(float3 &a, float3 b)
+{
+    a.x /= b.x;
+    a.y /= b.y;
+    a.z /= b.z;
+}
+inline __host__ __device__ float3 operator/(float3 a, float b)
+{
+    return make_float3(a.x / b, a.y / b, a.z / b);
+}
+inline __host__ __device__ void operator/=(float3 &a, float b)
+{
+    a.x /= b;
+    a.y /= b;
+    a.z /= b;
+}
+inline __host__ __device__ float3 operator/(float b, float3 a)
+{
+    return make_float3(b / a.x, b / a.y, b / a.z);
+}
+
+inline __host__ __device__ float4 operator/(float4 a, float4 b)
+{
+    return make_float4(a.x / b.x, a.y / b.y, a.z / b.z,  a.w / b.w);
+}
+inline __host__ __device__ void operator/=(float4 &a, float4 b)
+{
+    a.x /= b.x;
+    a.y /= b.y;
+    a.z /= b.z;
+    a.w /= b.w;
+}
+inline __host__ __device__ float4 operator/(float4 a, float b)
+{
+    return make_float4(a.x / b, a.y / b, a.z / b,  a.w / b);
+}
+inline __host__ __device__ void operator/=(float4 &a, float b)
+{
+    a.x /= b;
+    a.y /= b;
+    a.z /= b;
+    a.w /= b;
+}
+inline __host__ __device__ float4 operator/(float b, float4 a)
+{
+    return make_float4(b / a.x, b / a.y, b / a.z, b / a.w);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// min
+////////////////////////////////////////////////////////////////////////////////
+
+inline  __host__ __device__ float2 fminf(float2 a, float b)
+{
+    return make_float2(fminf(a.x, b), fminf(a.y, b));
+}
+inline __host__ __device__ float3 fminf(float3 a, float b)
+{
+    return make_float3(fminf(a.x, b), fminf(a.y, b), fminf(a.z, b));
+}
+inline  __host__ __device__ float4 fminf(float4 a, float b)
+{
+    return make_float4(fminf(a.x, b), fminf(a.y, b), fminf(a.z, b), fminf(a.w, b));
+}
+
+inline  __host__ __device__ float2 fminf(float2 a, float2 b)
+{
+    return make_float2(fminf(a.x, b.x), fminf(a.y, b.y));
+}
+inline __host__ __device__ float3 fminf(float3 a, float3 b)
+{
+    return make_float3(fminf(a.x, b.x), fminf(a.y, b.y), fminf(a.z, b.z));
+}
+inline  __host__ __device__ float4 fminf(float4 a, float4 b)
+{
+    return make_float4(fminf(a.x, b.x), fminf(a.y, b.y), fminf(a.z, b.z), fminf(a.w, b.w));
+}
+
+inline __host__ __device__ int2 min(int2 a, int b)
+{
+    return make_int2(min(a.x, b), min(a.y, b));
+}
+inline __host__ __device__ int3 min(int3 a, int b)
+{
+    return make_int3(min(a.x, b), min(a.y, b), min(a.z, b));
+}
+inline __host__ __device__ int4 min(int4 a, int b)
+{
+    return make_int4(min(a.x, b), min(a.y, b), min(a.z, b), min(a.w, b));
+}
+
+inline __host__ __device__ int2 min(int2 a, int2 b)
+{
+    return make_int2(min(a.x, b.x), min(a.y, b.y));
+}
+inline __host__ __device__ int3 min(int3 a, int3 b)
+{
+    return make_int3(min(a.x, b.x), min(a.y, b.y), min(a.z, b.z));
+}
+inline __host__ __device__ int4 min(int4 a, int4 b)
+{
+    return make_int4(min(a.x, b.x), min(a.y, b.y), min(a.z, b.z), min(a.w, b.w));
+}
+
+inline __host__ __device__ uint2 min(uint2 a, uint b)
+{
+    return make_uint2(min(a.x, b), min(a.y, b));
+}
+inline __host__ __device__ uint3 min(uint3 a, uint b)
+{
+    return make_uint3(min(a.x, b), min(a.y, b), min(a.z, b));
+}
+inline __host__ __device__ uint4 min(uint4 a, uint b)
+{
+    return make_uint4(min(a.x, b), min(a.y, b), min(a.z, b), min(a.w, b));
+}
+
+inline __host__ __device__ uint2 min(uint2 a, uint2 b)
+{
+    return make_uint2(min(a.x, b.x), min(a.y, b.y));
+}
+inline __host__ __device__ uint3 min(uint3 a, uint3 b)
+{
+    return make_uint3(min(a.x, b.x), min(a.y, b.y), min(a.z, b.z));
+}
+inline __host__ __device__ uint4 min(uint4 a, uint4 b)
+{
+    return make_uint4(min(a.x, b.x), min(a.y, b.y), min(a.z, b.z), min(a.w, b.w));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// max
+////////////////////////////////////////////////////////////////////////////////
+
+inline __host__ __device__ float2 fmaxf(float2 a, float b)
+{
+    return make_float2(fmaxf(a.x, b), fmaxf(a.y, b));
+}
+inline __host__ __device__ float3 fmaxf(float3 a, float b)
+{
+    return make_float3(fmaxf(a.x, b), fmaxf(a.y, b), fmaxf(a.z, b));
+}
+inline __host__ __device__ float4 fmaxf(float4 a, float b)
+{
+    return make_float4(fmaxf(a.x, b), fmaxf(a.y, b), fmaxf(a.z, b), fmaxf(a.w, b));
+}
+
+inline __host__ __device__ float2 fmaxf(float2 a, float2 b)
+{
+    return make_float2(fmaxf(a.x, b.x), fmaxf(a.y, b.y));
+}
+inline __host__ __device__ float3 fmaxf(float3 a, float3 b)
+{
+    return make_float3(fmaxf(a.x, b.x), fmaxf(a.y, b.y), fmaxf(a.z, b.z));
+}
+inline __host__ __device__ float4 fmaxf(float4 a, float4 b)
+{
+    return make_float4(fmaxf(a.x, b.x), fmaxf(a.y, b.y), fmaxf(a.z, b.z), fmaxf(a.w, b.w));
+}
+
+inline __host__ __device__ int2 max(int2 a, int b)
+{
+    return make_int2(max(a.x, b), max(a.y, b));
+}
+inline __host__ __device__ int3 max(int3 a, int b)
+{
+    return make_int3(max(a.x, b), max(a.y, b), max(a.z, b));
+}
+inline __host__ __device__ int4 max(int4 a, int b)
+{
+    return make_int4(max(a.x, b), max(a.y, b), max(a.z, b), max(a.w, b));
+}
+
+inline __host__ __device__ int2 max(int2 a, int2 b)
+{
+    return make_int2(max(a.x, b.x), max(a.y, b.y));
+}
+inline __host__ __device__ int3 max(int3 a, int3 b)
+{
+    return make_int3(max(a.x, b.x), max(a.y, b.y), max(a.z, b.z));
+}
+inline __host__ __device__ int4 max(int4 a, int4 b)
+{
+    return make_int4(max(a.x, b.x), max(a.y, b.y), max(a.z, b.z), max(a.w, b.w));
+}
+
+inline __host__ __device__ uint2 max(uint2 a, uint b)
+{
+    return make_uint2(max(a.x, b), max(a.y, b));
+}
+inline __host__ __device__ uint3 max(uint3 a, uint b)
+{
+    return make_uint3(max(a.x, b), max(a.y, b), max(a.z, b));
+}
+inline __host__ __device__ uint4 max(uint4 a, uint b)
+{
+    return make_uint4(max(a.x, b), max(a.y, b), max(a.z, b), max(a.w, b));
+}
+
+inline __host__ __device__ uint2 max(uint2 a, uint2 b)
+{
+    return make_uint2(max(a.x, b.x), max(a.y, b.y));
+}
+inline __host__ __device__ uint3 max(uint3 a, uint3 b)
+{
+    return make_uint3(max(a.x, b.x), max(a.y, b.y), max(a.z, b.z));
+}
+inline __host__ __device__ uint4 max(uint4 a, uint4 b)
+{
+    return make_uint4(max(a.x, b.x), max(a.y, b.y), max(a.z, b.z), max(a.w, b.w));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// lerp
+// - linear interpolation between a and b, based on value t in [0, 1] range
+////////////////////////////////////////////////////////////////////////////////
+
+inline __device__ __host__ float lerp(float a, float b, float t)
+{
+    return a + t*(b-a);
+}
+inline __device__ __host__ float2 lerp(float2 a, float2 b, float t)
+{
+    return a + t*(b-a);
+}
+inline __device__ __host__ float3 lerp(float3 a, float3 b, float t)
+{
+    return a + t*(b-a);
+}
+inline __device__ __host__ float4 lerp(float4 a, float4 b, float t)
+{
+    return a + t*(b-a);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// clamp
+// - clamp the value v to be in the range [a, b]
+////////////////////////////////////////////////////////////////////////////////
+
+inline __device__ __host__ float clamp(float f, float a, float b)
+{
+    return fmaxf(a, fminf(f, b));
+}
+inline __device__ __host__ int clamp(int f, int a, int b)
+{
+    return max(a, min(f, b));
+}
+inline __device__ __host__ uint clamp(uint f, uint a, uint b)
+{
+    return max(a, min(f, b));
+}
+
+inline __device__ __host__ float2 clamp(float2 v, float a, float b)
+{
+    return make_float2(clamp(v.x, a, b), clamp(v.y, a, b));
+}
+inline __device__ __host__ float2 clamp(float2 v, float2 a, float2 b)
+{
+    return make_float2(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y));
+}
+inline __device__ __host__ float3 clamp(float3 v, float a, float b)
+{
+    return make_float3(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b));
+}
+inline __device__ __host__ float3 clamp(float3 v, float3 a, float3 b)
+{
+    return make_float3(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z));
+}
+inline __device__ __host__ float4 clamp(float4 v, float a, float b)
+{
+    return make_float4(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b), clamp(v.w, a, b));
+}
+inline __device__ __host__ float4 clamp(float4 v, float4 a, float4 b)
+{
+    return make_float4(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z), clamp(v.w, a.w, b.w));
+}
+
+inline __device__ __host__ int2 clamp(int2 v, int a, int b)
+{
+    return make_int2(clamp(v.x, a, b), clamp(v.y, a, b));
+}
+inline __device__ __host__ int2 clamp(int2 v, int2 a, int2 b)
+{
+    return make_int2(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y));
+}
+inline __device__ __host__ int3 clamp(int3 v, int a, int b)
+{
+    return make_int3(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b));
+}
+inline __device__ __host__ int3 clamp(int3 v, int3 a, int3 b)
+{
+    return make_int3(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z));
+}
+inline __device__ __host__ int4 clamp(int4 v, int a, int b)
+{
+    return make_int4(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b), clamp(v.w, a, b));
+}
+inline __device__ __host__ int4 clamp(int4 v, int4 a, int4 b)
+{
+    return make_int4(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z), clamp(v.w, a.w, b.w));
+}
+
+inline __device__ __host__ uint2 clamp(uint2 v, uint a, uint b)
+{
+    return make_uint2(clamp(v.x, a, b), clamp(v.y, a, b));
+}
+inline __device__ __host__ uint2 clamp(uint2 v, uint2 a, uint2 b)
+{
+    return make_uint2(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y));
+}
+inline __device__ __host__ uint3 clamp(uint3 v, uint a, uint b)
+{
+    return make_uint3(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b));
+}
+inline __device__ __host__ uint3 clamp(uint3 v, uint3 a, uint3 b)
+{
+    return make_uint3(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z));
+}
+inline __device__ __host__ uint4 clamp(uint4 v, uint a, uint b)
+{
+    return make_uint4(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b), clamp(v.w, a, b));
+}
+inline __device__ __host__ uint4 clamp(uint4 v, uint4 a, uint4 b)
+{
+    return make_uint4(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z), clamp(v.w, a.w, b.w));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// dot product
+////////////////////////////////////////////////////////////////////////////////
+
+inline __host__ __device__ float dot(float2 a, float2 b)
+{
+    return a.x * b.x + a.y * b.y;
+}
+inline __host__ __device__ float dot(float3 a, float3 b)
+{
+    return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+inline __host__ __device__ float dot(float4 a, float4 b)
+{
+    return a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
+}
+
+inline __host__ __device__ int dot(int2 a, int2 b)
+{
+    return a.x * b.x + a.y * b.y;
+}
+inline __host__ __device__ int dot(int3 a, int3 b)
+{
+    return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+inline __host__ __device__ int dot(int4 a, int4 b)
+{
+    return a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
+}
+
+inline __host__ __device__ uint dot(uint2 a, uint2 b)
+{
+    return a.x * b.x + a.y * b.y;
+}
+inline __host__ __device__ uint dot(uint3 a, uint3 b)
+{
+    return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+inline __host__ __device__ uint dot(uint4 a, uint4 b)
+{
+    return a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// length
+////////////////////////////////////////////////////////////////////////////////
+
+inline __host__ __device__ float length(float2 v)
+{
+    return sqrtf(dot(v, v));
+}
+inline __host__ __device__ float length(float3 v)
+{
+    return sqrtf(dot(v, v));
+}
+inline __host__ __device__ float length(float4 v)
+{
+    return sqrtf(dot(v, v));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// normalize
+////////////////////////////////////////////////////////////////////////////////
+
+inline __host__ __device__ float2 normalize(float2 v)
+{
+    float invLen = rsqrtf(dot(v, v));
+    return v * invLen;
+}
+inline __host__ __device__ float3 normalize(float3 v)
+{
+    float invLen = rsqrtf(dot(v, v));
+    return v * invLen;
+}
+inline __host__ __device__ float4 normalize(float4 v)
+{
+    float invLen = rsqrtf(dot(v, v));
+    return v * invLen;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// floor
+////////////////////////////////////////////////////////////////////////////////
+
+inline __host__ __device__ float2 floorf(float2 v)
+{
+    return make_float2(floorf(v.x), floorf(v.y));
+}
+inline __host__ __device__ float3 floorf(float3 v)
+{
+    return make_float3(floorf(v.x), floorf(v.y), floorf(v.z));
+}
+inline __host__ __device__ float4 floorf(float4 v)
+{
+    return make_float4(floorf(v.x), floorf(v.y), floorf(v.z), floorf(v.w));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// frac - returns the fractional portion of a scalar or each vector component
+////////////////////////////////////////////////////////////////////////////////
+
+inline __host__ __device__ float fracf(float v)
+{
+    return v - floorf(v);
+}
+inline __host__ __device__ float2 fracf(float2 v)
+{
+    return make_float2(fracf(v.x), fracf(v.y));
+}
+inline __host__ __device__ float3 fracf(float3 v)
+{
+    return make_float3(fracf(v.x), fracf(v.y), fracf(v.z));
+}
+inline __host__ __device__ float4 fracf(float4 v)
+{
+    return make_float4(fracf(v.x), fracf(v.y), fracf(v.z), fracf(v.w));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// fmod
+////////////////////////////////////////////////////////////////////////////////
+
+inline __host__ __device__ float2 fmodf(float2 a, float2 b)
+{
+    return make_float2(fmodf(a.x, b.x), fmodf(a.y, b.y));
+}
+inline __host__ __device__ float3 fmodf(float3 a, float3 b)
+{
+    return make_float3(fmodf(a.x, b.x), fmodf(a.y, b.y), fmodf(a.z, b.z));
+}
+inline __host__ __device__ float4 fmodf(float4 a, float4 b)
+{
+    return make_float4(fmodf(a.x, b.x), fmodf(a.y, b.y), fmodf(a.z, b.z), fmodf(a.w, b.w));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// absolute value
+////////////////////////////////////////////////////////////////////////////////
+
+inline __host__ __device__ float2 fabs(float2 v)
+{
+    return make_float2(fabs(v.x), fabs(v.y));
+}
+inline __host__ __device__ float3 fabs(float3 v)
+{
+    return make_float3(fabs(v.x), fabs(v.y), fabs(v.z));
+}
+inline __host__ __device__ float4 fabs(float4 v)
+{
+    return make_float4(fabs(v.x), fabs(v.y), fabs(v.z), fabs(v.w));
+}
+inline __host__ __device__ float2 fabsf(float2 v)
+{
+    return make_float2(fabsf(v.x), fabsf(v.y));
+}
+inline __host__ __device__ float3 fabsf(float3 v)
+{
+    return make_float3(fabsf(v.x), fabsf(v.y), fabsf(v.z));
+}
+inline __host__ __device__ float4 fabsf(float4 v)
+{
+    return make_float4(fabsf(v.x), fabsf(v.y), fabsf(v.z), fabsf(v.w));
+}
+
+inline __host__ __device__ int2 abs(int2 v)
+{
+    return make_int2(abs(v.x), abs(v.y));
+}
+inline __host__ __device__ int3 abs(int3 v)
+{
+    return make_int3(abs(v.x), abs(v.y), abs(v.z));
+}
+inline __host__ __device__ int4 abs(int4 v)
+{
+    return make_int4(abs(v.x), abs(v.y), abs(v.z), abs(v.w));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// reflect
+// - returns reflection of incident ray I around surface normal N
+// - N should be normalized, reflected vector's length is equal to length of I
+////////////////////////////////////////////////////////////////////////////////
+
+inline __host__ __device__ float3 reflect(float3 i, float3 n)
+{
+    return i - 2.0f * n * dot(n,i);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// cross product
+////////////////////////////////////////////////////////////////////////////////
+
+inline __host__ __device__ float3 cross(float3 a, float3 b)
+{
+    return make_float3(a.y*b.z - a.z*b.y, a.z*b.x - a.x*b.z, a.x*b.y - a.y*b.x);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// smoothstep
+// - returns 0 if x < a
+// - returns 1 if x > b
+// - otherwise returns smooth interpolation between 0 and 1 based on x
+////////////////////////////////////////////////////////////////////////////////
+
+inline __device__ __host__ float smoothstep(float a, float b, float x)
+{
+    float y = clamp((x - a) / (b - a), 0.0f, 1.0f);
+    return (y*y*(3.0f - (2.0f*y)));
+}
+inline __device__ __host__ float2 smoothstep(float2 a, float2 b, float2 x)
+{
+    float2 y = clamp((x - a) / (b - a), 0.0f, 1.0f);
+    return (y*y*(make_float2(3.0f) - (make_float2(2.0f)*y)));
+}
+inline __device__ __host__ float3 smoothstep(float3 a, float3 b, float3 x)
+{
+    float3 y = clamp((x - a) / (b - a), 0.0f, 1.0f);
+    return (y*y*(make_float3(3.0f) - (make_float3(2.0f)*y)));
+}
+inline __device__ __host__ float4 smoothstep(float4 a, float4 b, float4 x)
+{
+    float4 y = clamp((x - a) / (b - a), 0.0f, 1.0f);
+    return (y*y*(make_float4(3.0f) - (make_float4(2.0f)*y)));
+}

--- a/fastgs/utils/torch_utils.h
+++ b/fastgs/utils/torch_utils.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <torch/extension.h>
+#include <functional>
+
+inline std::function<char*(size_t N)> resize_function_wrapper(torch::Tensor& t) {
+    auto lambda = [&t](const size_t N) {
+        t.resize_({static_cast<long long>(N)});
+		return reinterpret_cast<char*>(t.contiguous().data_ptr());
+    };
+    return lambda;
+}
+
+#define CHECK_INPUT(debug, tensor, name) \
+if (debug) { \
+if (!tensor.is_cuda() || !tensor.is_floating_point() || !tensor.is_contiguous()) { \
+throw std::runtime_error("Input tensor '" + std::string(name) + "' must be a contiguous CUDA float tensor."); \
+} \
+}

--- a/fastgs/utils/utils.h
+++ b/fastgs/utils/utils.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <cuda_runtime.h>
+
+#define CHECK_CUDA(debug, name) \
+if(debug) { \
+auto ret = cudaDeviceSynchronize(); \
+if (ret != cudaSuccess) { \
+std::cerr << "\n[CUDA ERROR] in " << name << " " << __FILE__ << "\nLine " << __LINE__ << ": " << cudaGetErrorString(ret); \
+throw std::runtime_error(cudaGetErrorString(ret)); \
+} \
+}
+
+template <typename T>
+inline __host__ __device__ T div_round_up(T value, T divisor) {
+	return (value + divisor - 1) / divisor;
+}

--- a/gsplat/Ops.h
+++ b/gsplat/Ops.h
@@ -287,6 +287,15 @@ std::tuple<at::Tensor, at::Tensor> relocation(
     const int n_max
 );
 
+void add_noise(
+    at::Tensor raw_opacities, // [N]
+    at::Tensor raw_scales,    // [N, 3]
+    at::Tensor raw_quats,     // [N, 4]
+    at::Tensor noise,         // [N, 3]
+    at::Tensor means,         // [N, 3]
+    const float current_lr
+);
+
 // Use uncented transform to project 3D gaussians to 2D. (none differentiable)
 // https://arxiv.org/abs/2412.12507
 std::tuple<

--- a/gsplat/Relocation.cpp
+++ b/gsplat/Relocation.cpp
@@ -33,4 +33,24 @@ std::tuple<at::Tensor, at::Tensor> relocation(
     return std::make_tuple(new_opacities, new_scales);
 }
 
+void add_noise(
+    at::Tensor raw_opacities, // [N]
+    at::Tensor raw_scales,    // [N, 3]
+    at::Tensor raw_quats,     // [N, 4]
+    at::Tensor noise,         // [N, 3]
+    at::Tensor means,         // [N, 3]
+    const float current_lr
+) {
+    DEVICE_GUARD(raw_opacities);
+    CHECK_INPUT(raw_opacities);
+    CHECK_INPUT(raw_scales);
+    CHECK_INPUT(raw_quats);
+    CHECK_INPUT(noise);
+    CHECK_INPUT(means);
+
+    launch_add_noise_kernel(
+        raw_opacities, raw_scales, raw_quats, noise, means, current_lr
+    );
+}
+
 } // namespace gsplat

--- a/gsplat/Relocation.h
+++ b/gsplat/Relocation.h
@@ -20,4 +20,13 @@ void launch_relocation_kernel(
     at::Tensor new_scales     // [N, 3]
 );
 
+void launch_add_noise_kernel(
+    at::Tensor raw_opacities, // [N]
+    at::Tensor raw_scales,    // [N, 3]
+    at::Tensor raw_quats,     // [N, 4]
+    at::Tensor noise,         // [N, 3]
+    at::Tensor means,         // [N, 3]
+    const float current_lr
+);
+
 }

--- a/gsplat/RelocationCUDA.cu
+++ b/gsplat/RelocationCUDA.cu
@@ -88,4 +88,104 @@ void launch_relocation_kernel(
     );
 }
 
+inline __device__ mat3 raw_quat_to_rotmat(const vec4 raw_quat) {
+    float w = raw_quat[0], x = raw_quat[1], y = raw_quat[2], z = raw_quat[3];
+    // normalize
+    float inv_norm = fminf(rsqrt(x * x + y * y + z * z + w * w), 1e+12f); // match torch normalize
+    x *= inv_norm;
+    y *= inv_norm;
+    z *= inv_norm;
+    w *= inv_norm;
+    float x2 = x * x, y2 = y * y, z2 = z * z;
+    float xy = x * y, xz = x * z, yz = y * z;
+    float wx = w * x, wy = w * y, wz = w * z;
+    return mat3(
+        (1.f - 2.f * (y2 + z2)),
+        (2.f * (xy + wz)),
+        (2.f * (xz - wy)), // 1st col
+        (2.f * (xy - wz)),
+        (1.f - 2.f * (x2 + z2)),
+        (2.f * (yz + wx)), // 2nd col
+        (2.f * (xz + wy)),
+        (2.f * (yz - wx)),
+        (1.f - 2.f * (x2 + y2)) // 3rd col
+    );
+}
+
+template <typename scalar_t>
+__global__ void add_noise_kernel(
+    int N,
+    scalar_t *raw_opacities,
+    scalar_t *raw_scales,
+    scalar_t *raw_quats,
+    scalar_t *noise,
+    scalar_t *means,
+    float current_lr
+) {
+    int idx = threadIdx.x + blockIdx.x * blockDim.x;
+    if (idx >= N)
+        return;
+    
+    int idx_3d = 3 * idx;
+
+    const vec3 raw_scale = glm::make_vec3(raw_scales + idx_3d);
+    mat3 S2 = mat3(__expf(2.f * raw_scale[0]), 0.f, 0.f, 0.f, __expf(2.f * raw_scale[1]), 0.f, 0.f, 0.f, __expf(2.f * raw_scale[2]));
+
+    vec4 raw_quat = glm::make_vec4(raw_quats + 4 * idx);
+    mat3 R = raw_quat_to_rotmat(raw_quat);
+
+    mat3 covariance = R * S2 * glm::transpose(R);
+
+    vec3 transformed_noise = covariance * glm::make_vec3(noise + idx_3d);
+    
+    float opacity = __frcp_rn(1.f + __expf(-raw_opacities[idx]));
+    float op_sigmoid = __frcp_rn(1.f + __expf(100.f * opacity - 0.5f));
+    float noise_factor = current_lr * op_sigmoid;
+    
+    means[idx_3d] += noise_factor * transformed_noise.x;
+    means[idx_3d + 1] += noise_factor * transformed_noise.y;
+    means[idx_3d + 2] += noise_factor * transformed_noise.z;
+}
+
+void launch_add_noise_kernel(
+    at::Tensor raw_opacities, // [N]
+    at::Tensor raw_scales,    // [N, 3]
+    at::Tensor raw_quats,     // [N, 4]
+    at::Tensor noise,         // [N, 3]
+    at::Tensor means,         // [N, 3]
+    const float current_lr
+) {
+    uint32_t N = raw_opacities.size(0);
+
+    int64_t n_elements = N;
+    dim3 threads(256);
+    dim3 grid((n_elements + threads.x - 1) / threads.x);
+    int64_t shmem_size = 0; // No shared memory used in this kernel
+
+    if (n_elements == 0) {
+        // skip the kernel launch if there are no elements
+        return;
+    }
+
+    AT_DISPATCH_FLOATING_TYPES(
+        raw_opacities.scalar_type(),
+        "add_noise_kernel",
+        [&]() {
+            add_noise_kernel<scalar_t>
+                <<<grid,
+                   threads,
+                   shmem_size,
+                   at::cuda::getCurrentCUDAStream()>>>(
+                    N,
+                    raw_opacities.data_ptr<scalar_t>(),
+                    raw_scales.data_ptr<scalar_t>(),
+                    raw_quats.data_ptr<scalar_t>(),
+                    noise.data_ptr<scalar_t>(),
+                    means.data_ptr<scalar_t>(),
+                    current_lr
+                );
+        }
+    );
+}
+
 } // namespace gsplat

--- a/include/core/camera.hpp
+++ b/include/core/camera.hpp
@@ -30,12 +30,32 @@ public:
     // Load image from disk and return it
     torch::Tensor load_and_get_image(int resolution = -1);
 
+    // Get number of bytes in the image file
+    size_t get_num_bytes_from_file() const;
+
     // Accessors - now return const references to avoid copies
     const torch::Tensor& world_view_transform() const {
         return _world_view_transform;
     }
+    const torch::Tensor& cam_position() const {
+        return _cam_position;
+    }
+
+    void enable_image_caching() {
+        _cache_enabled = true;
+    }
 
     torch::Tensor K() const;
+
+    std::tuple<float, float, float, float> get_intrinsics() const {
+            const float tanfovx = std::tan(_FoVx * 0.5f);
+        const float tanfovy = std::tan(_FoVy * 0.5f);
+        const float fx = _image_width / (2.f * tanfovx);
+        const float fy = _image_height / (2.f * tanfovy);
+        const float cx = _image_width / 2.0f;
+        const float cy = _image_height / 2.0f;
+        return std::make_tuple(fx, fy, cx, cy);
+    }
 
     int image_height() const noexcept { return _image_height; }
     int image_width() const noexcept { return _image_width; }
@@ -58,4 +78,9 @@ private:
 
     // GPU tensors (computed on demand)
     torch::Tensor _world_view_transform;
+    torch::Tensor _cam_position;
+
+    // Optional image caching in VRAM
+    bool _cache_enabled = false;
+    torch::Tensor _image_cache = torch::empty({0});
 };

--- a/include/core/dataset.hpp
+++ b/include/core/dataset.hpp
@@ -76,6 +76,27 @@ public:
 
     Split get_split() const { return _split; }
 
+    size_t get_num_bytes() const {
+        if (_cameras.empty()) {
+            return 0;
+        }
+        size_t total_bytes = 0;
+        for (const auto& cam : _cameras) {
+            total_bytes += cam->get_num_bytes_from_file();
+        }
+        // Adjust for resolution factor if specified
+        if (_datasetConfig.resolution > 0) {
+            total_bytes /= _datasetConfig.resolution * _datasetConfig.resolution;
+        }
+        return total_bytes;
+    }
+
+    void enable_image_caching() const {
+        for (const auto& cam : _cameras) {
+            cam->enable_image_caching();
+        }
+    }
+
 private:
     std::vector<std::shared_ptr<Camera>> _cameras;
     const gs::param::DatasetConfig& _datasetConfig;

--- a/include/core/fast_rasterizer.hpp
+++ b/include/core/fast_rasterizer.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "rasterization_api.h"
+#include "core/rasterizer.hpp"
+#include "core/camera.hpp"
+#include "core/splat_data.hpp"
+#include <torch/torch.h>
+
+namespace gs {
+
+    // Wrapper function to use fastgs backend for rendering
+    RenderOutput fast_rasterize(
+        Camera& viewpoint_camera,
+        const SplatData& gaussian_model,
+        torch::Tensor& bg_color);
+
+} // namespace gs

--- a/include/core/fast_rasterizer_autograd.hpp
+++ b/include/core/fast_rasterizer_autograd.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "rasterization_api.h"
+#include <torch/torch.h>
+
+namespace gs {
+
+    // Autograd function for projection
+    class FastGSRasterize : public torch::autograd::Function<FastGSRasterize> {
+    public:
+        static torch::autograd::tensor_list forward(
+            torch::autograd::AutogradContext* ctx,
+            const torch::Tensor& means,                              // [N, 3]
+            const torch::Tensor& scales_raw,                         // [N, 3]
+            const torch::Tensor& rotations_raw,                      // [N, 4]
+            const torch::Tensor& opacities_raw,                      // [N, 1]
+            const torch::Tensor& sh_coefficients_0,                  // [N, 1, 3]
+            const torch::Tensor& sh_coefficients_rest,               // [C, B-1, 3]
+            torch::Tensor& densification_info,                       // [2, N] or empty tensor
+            const fast_gs::rasterization::FastGSSettings& settings); // rasterizer settings
+
+        static torch::autograd::tensor_list backward(
+            torch::autograd::AutogradContext* ctx,
+            torch::autograd::tensor_list grad_outputs);
+    };
+
+} // namespace gs

--- a/include/core/fused_adam.hpp
+++ b/include/core/fused_adam.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <memory>
+#include <torch/torch.h>
+#include <vector>
+
+namespace gs {
+
+    /**
+     * @brief FusedAdam optimizer
+     *
+     * The implementation uses fused CUDA kernels for better performance.
+     */
+    class FusedAdam : public torch::optim::Optimizer {
+    public:
+        struct Options : public torch::optim::OptimizerCloneableOptions<Options> {
+            Options(double lr = 1e-3) : lr_(lr) {}
+
+            Options& lr(double lr) {
+                lr_ = lr;
+                return *this;
+            }
+
+            Options& betas(const std::tuple<double, double>& betas) {
+                betas_ = betas;
+                return *this;
+            }
+
+            Options& eps(double eps) {
+                eps_ = eps;
+                return *this;
+            }
+
+            Options& weight_decay(double weight_decay) {
+                weight_decay_ = weight_decay;
+                return *this;
+            }
+
+            double lr() const { return lr_; }
+            const std::tuple<double, double>& betas() const { return betas_; }
+            double eps() const { return eps_; }
+            double weight_decay() const { return weight_decay_; }
+
+        private:
+            double lr_ = 1e-3;
+            std::tuple<double, double> betas_ = std::make_tuple(0.9, 0.999);
+            double eps_ = 1e-8;
+            double weight_decay_ = 0;
+        };
+
+        struct AdamParamState : public torch::optim::OptimizerParamState {
+            torch::Tensor exp_avg;
+            torch::Tensor exp_avg_sq;
+            torch::Tensor max_exp_avg_sq; // For amsgrad variant (not used currently)
+            int64_t step_count = 0;
+
+            void serialize(torch::serialize::OutputArchive& archive) const override {
+                archive.write("exp_avg", exp_avg);
+                archive.write("exp_avg_sq", exp_avg_sq);
+                archive.write("step", step_count);
+                if (max_exp_avg_sq.defined()) {
+                    archive.write("max_exp_avg_sq", max_exp_avg_sq);
+                }
+            }
+        };
+
+        explicit FusedAdam(std::vector<torch::optim::OptimizerParamGroup> param_groups, std::unique_ptr<Options> options)
+            : Optimizer(std::move(param_groups),
+                        std::unique_ptr<torch::optim::OptimizerOptions>(std::move(options))) {}
+
+        explicit FusedAdam(std::vector<torch::Tensor> params, std::unique_ptr<Options> options)
+            : Optimizer({torch::optim::OptimizerParamGroup(std::move(params))}, std::unique_ptr<torch::optim::OptimizerOptions>(std::move(options))) {}
+
+        // Override the base class step() with proper signature
+        torch::Tensor step(LossClosure closure) override;
+
+        /**
+         * @brief Perform optimization step
+         */
+        void step(int iteration);
+
+        void zero_grad(bool set_to_none, int iteration);
+
+    private:
+        const Options& options() const {
+            return static_cast<const Options&>(defaults());
+        }
+    };
+
+} // namespace gs

--- a/include/core/image_io.hpp
+++ b/include/core/image_io.hpp
@@ -10,6 +10,8 @@
 #include <torch/torch.h>
 #include <vector>
 
+std::tuple<int, int, int>
+get_image_info(std::filesystem::path p);
 // Existing functions
 std::tuple<unsigned char*, int, int, int>
 load_image(std::filesystem::path p, int res_div = -1);

--- a/include/core/mcmc.hpp
+++ b/include/core/mcmc.hpp
@@ -2,6 +2,7 @@
 
 #include "core/istrategy.hpp"
 #include "core/selective_adam.hpp"
+#include "core/fused_adam.hpp"
 #include <memory>
 #include <torch/torch.h>
 

--- a/include/core/splat_data.hpp
+++ b/include/core/splat_data.hpp
@@ -50,11 +50,17 @@ public:
 
     // Raw tensor access for optimization (inline for performance)
     inline torch::Tensor& means() { return _means; }
+    inline const torch::Tensor& means() const { return _means; }
     inline torch::Tensor& opacity_raw() { return _opacity; }
+    inline const torch::Tensor& opacity_raw() const { return _opacity; }
     inline torch::Tensor& rotation_raw() { return _rotation; }
+    inline const torch::Tensor& rotation_raw() const { return _rotation; }
     inline torch::Tensor& scaling_raw() { return _scaling; }
+    inline const torch::Tensor& scaling_raw() const { return _scaling; }
     inline torch::Tensor& sh0() { return _sh0; }
+    inline const torch::Tensor& sh0() const { return _sh0; }
     inline torch::Tensor& shN() { return _shN; }
+    inline const torch::Tensor& shN() const { return _shN; }
     inline torch::Tensor& max_radii2D() { return _max_radii2D; }
 
     // Utility methods

--- a/src/fast_rasterizer.cpp
+++ b/src/fast_rasterizer.cpp
@@ -1,0 +1,66 @@
+#include "core/fast_rasterizer.hpp"
+#include "core/fast_rasterizer_autograd.hpp"
+#include <torch/torch.h>
+
+namespace gs {
+
+    using torch::indexing::None;
+    using torch::indexing::Slice;
+
+    // Main render function
+    RenderOutput fast_rasterize(
+        Camera& viewpoint_camera,
+        const SplatData& gaussian_model,
+        torch::Tensor& bg_color) {
+
+        // Get camera parameters
+        const int width = static_cast<int>(viewpoint_camera.image_width());
+        const int height = static_cast<int>(viewpoint_camera.image_height());
+        auto [fx, fy, cx, cy] = viewpoint_camera.get_intrinsics();
+
+        // Get Gaussian parameters
+        auto means = gaussian_model.means();
+        auto raw_opacities = gaussian_model.opacity_raw();
+        auto raw_scales = gaussian_model.scaling_raw();
+        auto raw_rotations = gaussian_model.rotation_raw();
+        auto sh0 = gaussian_model.sh0();
+        auto shN = gaussian_model.shN();
+
+        const int sh_degree = gaussian_model.get_active_sh_degree();
+        const int active_sh_bases = (sh_degree + 1) * (sh_degree + 1);
+
+        constexpr float near_plane = 0.2f;
+        constexpr float far_plane = 1000.0f;
+
+        auto densification_info = torch::empty({0});
+
+        fast_gs::rasterization::FastGSSettings settings;
+        settings.w2c = viewpoint_camera.world_view_transform();
+        settings.cam_position = viewpoint_camera.cam_position();
+        settings.bg_color = bg_color;
+        settings.active_sh_bases = active_sh_bases;
+        settings.width = width;
+        settings.height = height;
+        settings.focal_x = fx;
+        settings.focal_y = fy;
+        settings.center_x = cx;
+        settings.center_y = cy;
+        settings.near_plane = near_plane;
+        settings.far_plane = far_plane;
+
+        torch::Tensor image = FastGSRasterize::apply(
+            means,
+            raw_scales,
+            raw_rotations,
+            raw_opacities,
+            sh0,
+            shN,
+            densification_info,
+            settings)[0];
+
+        RenderOutput output;
+        output.image = image;
+        return output;
+    }
+
+} // namespace gs

--- a/src/fast_rasterizer_autograd.cpp
+++ b/src/fast_rasterizer_autograd.cpp
@@ -1,0 +1,159 @@
+#include "core/fast_rasterizer_autograd.hpp"
+
+namespace gs {
+
+    // FastGSRasterize implementation
+    torch::autograd::tensor_list FastGSRasterize::forward(
+        torch::autograd::AutogradContext* ctx,
+        const torch::Tensor& means,                               // [N, 3]
+        const torch::Tensor& scales_raw,                          // [N, 3]
+        const torch::Tensor& rotations_raw,                       // [N, 4]
+        const torch::Tensor& opacities_raw,                       // [N, 1]
+        const torch::Tensor& sh_coefficients_0,                   // [N, 1, 3]
+        const torch::Tensor& sh_coefficients_rest,                // [C, B-1, 3]
+        torch::Tensor& densification_info,                        // [2, N] or empty tensor
+        const fast_gs::rasterization::FastGSSettings& settings) { // rasterizer settings
+
+        auto outputs = fast_gs::rasterization::forward_wrapper(
+            means,
+            scales_raw,
+            rotations_raw,
+            opacities_raw,
+            sh_coefficients_0,
+            sh_coefficients_rest,
+            settings.w2c,
+            settings.cam_position,
+            settings.bg_color,
+            settings.active_sh_bases,
+            settings.width,
+            settings.height,
+            settings.focal_x,
+            settings.focal_y,
+            settings.center_x,
+            settings.center_y,
+            settings.near_plane,
+            settings.far_plane
+        );
+
+        auto image = std::get<0>(outputs);
+        auto per_primitive_buffers = std::get<1>(outputs);
+        auto per_tile_buffers = std::get<2>(outputs);
+        auto per_instance_buffers = std::get<3>(outputs);
+        auto per_bucket_buffers = std::get<4>(outputs);
+        int n_visible_primitives = std::get<5>(outputs);
+        int n_instances = std::get<6>(outputs);
+        int n_buckets = std::get<7>(outputs);
+        int primitive_primitive_indices_selector = std::get<8>(outputs);
+        int instance_primitive_indices_selector = std::get<9>(outputs);
+
+        // Save for backward
+        ctx->save_for_backward({
+            image,
+            means,
+            scales_raw,
+            rotations_raw,
+            sh_coefficients_rest,
+            per_primitive_buffers,
+            per_tile_buffers,
+            per_instance_buffers,
+            per_bucket_buffers,
+            densification_info
+        });
+        ctx->mark_non_differentiable({
+            per_primitive_buffers,
+            per_tile_buffers,
+            per_instance_buffers,
+            per_bucket_buffers,
+            densification_info
+        });
+
+        ctx->saved_data["w2c"] = settings.w2c;
+        ctx->saved_data["cam_position"] = settings.cam_position;
+        ctx->saved_data["bg_color"] = settings.bg_color;
+        ctx->saved_data["active_sh_bases"] = settings.active_sh_bases;
+        ctx->saved_data["width"] = settings.width;
+        ctx->saved_data["height"] = settings.height;
+        ctx->saved_data["focal_x"] = settings.focal_x;
+        ctx->saved_data["focal_y"] = settings.focal_y;
+        ctx->saved_data["center_x"] = settings.center_x;
+        ctx->saved_data["center_y"] = settings.center_y;
+        ctx->saved_data["near_plane"] = settings.near_plane;
+        ctx->saved_data["far_plane"] = settings.far_plane;
+        ctx->saved_data["n_visible_primitives"] = n_visible_primitives;
+        ctx->saved_data["n_instances"] = n_instances;
+        ctx->saved_data["n_buckets"] = n_buckets;
+        ctx->saved_data["primitive_primitive_indices_selector"] = primitive_primitive_indices_selector;
+        ctx->saved_data["instance_primitive_indices_selector"] = instance_primitive_indices_selector;
+
+        return {image};
+    }
+
+    torch::autograd::tensor_list FastGSRasterize::backward(
+        torch::autograd::AutogradContext* ctx,
+        torch::autograd::tensor_list grad_outputs) {
+
+        auto grad_image = grad_outputs[0];
+
+        auto saved = ctx->get_saved_variables();
+        const torch::Tensor& image = saved[0];
+        const torch::Tensor& means = saved[1];
+        const torch::Tensor& scales_raw = saved[2];
+        const torch::Tensor& rotations_raw = saved[3];
+        const torch::Tensor& sh_coefficients_rest = saved[4];
+        const torch::Tensor& per_primitive_buffers = saved[5];
+        const torch::Tensor& per_tile_buffers = saved[6];
+        const torch::Tensor& per_instance_buffers = saved[7];
+        const torch::Tensor& per_bucket_buffers = saved[8];
+        torch::Tensor densification_info = saved[9]; // FIXME: this apparently is not the orginal tensor due to libtorch being weird, but its not required with MCMC anyways
+
+        auto outputs = fast_gs::rasterization::backward_wrapper(
+            densification_info,
+            grad_image,
+            image,
+            means,
+            scales_raw,
+            rotations_raw,
+            sh_coefficients_rest,
+            per_primitive_buffers,
+            per_tile_buffers,
+            per_instance_buffers,
+            per_bucket_buffers,
+            ctx->saved_data["w2c"].toTensor(),
+            ctx->saved_data["cam_position"].toTensor(),
+            ctx->saved_data["bg_color"].toTensor(),
+            ctx->saved_data["active_sh_bases"].toInt(),
+            ctx->saved_data["width"].toInt(),
+            ctx->saved_data["height"].toInt(),
+            static_cast<float>(ctx->saved_data["focal_x"].toDouble()),
+            static_cast<float>(ctx->saved_data["focal_y"].toDouble()),
+            static_cast<float>(ctx->saved_data["center_x"].toDouble()),
+            static_cast<float>(ctx->saved_data["center_y"].toDouble()),
+            static_cast<float>(ctx->saved_data["near_plane"].toDouble()),
+            static_cast<float>(ctx->saved_data["far_plane"].toDouble()),
+            ctx->saved_data["n_visible_primitives"].toInt(),
+            ctx->saved_data["n_instances"].toInt(),
+            ctx->saved_data["n_buckets"].toInt(),
+            ctx->saved_data["primitive_primitive_indices_selector"].toInt(),
+            ctx->saved_data["instance_primitive_indices_selector"].toInt()
+        );
+
+        auto grad_means = std::get<0>(outputs);
+        auto grad_scales_raw = std::get<1>(outputs);
+        auto grad_rotations_raw = std::get<2>(outputs);
+        auto grad_opacities_raw = std::get<3>(outputs);
+        auto grad_sh_coefficients_0 = std::get<4>(outputs);
+        auto grad_sh_coefficients_rest = std::get<5>(outputs);
+
+        return {
+            grad_means,
+            grad_scales_raw,
+            grad_rotations_raw,
+            grad_opacities_raw,
+            grad_sh_coefficients_0,
+            grad_sh_coefficients_rest,
+            torch::Tensor(), // densification_info
+            torch::Tensor(), // settings
+        };
+    }
+
+} // namespace gs

--- a/src/fused_adam.cpp
+++ b/src/fused_adam.cpp
@@ -1,0 +1,115 @@
+#include "core/fused_adam.hpp"
+#include "adam_api.h"
+#include <torch/torch.h>
+
+// TODO: This is just a gimmick for the bounty. I don't think it should be integrated into the main codebase.
+// TODO: Removing the SH step skipping also means that the custom zero_grad() method is no longer needed.
+// TODO: All skipping conditions assume that iteration count starts at 1 (which is it currently does).
+// Between iteration 1000 and 25000, we can skip every second step for higher degree SH coefficients.
+// This does push the bounty benchmark below 20 minutes, but I don't really like the practical implications.
+// It also causes a *very* small drop in quality metrics and robustness. Thus, I disable it by default.
+#define SKIP_SH_STEPS false
+
+namespace gs {
+
+    torch::Tensor FusedAdam::step(LossClosure closure) {
+        TORCH_CHECK(false, "FusedAdam does not support closures.");
+        return {};
+    }
+
+    void FusedAdam::step(int iteration) {
+        torch::NoGradGuard no_grad;
+
+        // Get global options
+        const auto& global_options = options();
+
+        int i = 0; // HACK: counter to track what Gaussian parameter we are on
+        for (auto& group : param_groups()) {
+            ++i;
+
+            // For each group, check if it has specific options
+            double lr = global_options.lr();
+            double eps = global_options.eps();
+            auto [beta1, beta2] = global_options.betas();
+
+            // If the group has its own options, use those
+            if (group.has_options()) {
+                if (auto* group_opts = dynamic_cast<const Options*>(&group.options())) {
+                    lr = group_opts->lr();
+                    eps = group_opts->eps();
+                    std::tie(beta1, beta2) = group_opts->betas();
+                }
+            }
+
+            for (auto& param : group.params()) {
+                if (!param.grad().defined()) {
+                    continue;
+                }
+
+                // Lazy state initialization
+                auto state_ptr = state_.find(param.unsafeGetTensorImpl());
+                if (state_ptr == state_.end()) {
+                    auto new_state = std::make_unique<AdamParamState>();
+                    new_state->step_count = 0;
+                    new_state->exp_avg = torch::zeros_like(param, torch::MemoryFormat::Preserve);
+                    new_state->exp_avg_sq = torch::zeros_like(param, torch::MemoryFormat::Preserve);
+
+                    state_[param.unsafeGetTensorImpl()] = std::move(new_state);
+                    state_ptr = state_.find(param.unsafeGetTensorImpl());
+                }
+
+                auto& state = static_cast<AdamParamState&>(*state_ptr->second);
+
+                // Increment step
+                state.step_count++;
+
+                // Higher degree SH coefficients are not used in the first 1000 iterations so this is a free speed up
+                if (i == 3 && iteration <= 1000) continue;
+                
+                if constexpr (SKIP_SH_STEPS) {
+                    // Skip every second step during training except for the last 5000 iterations
+                    if (i == 3 && (iteration % 2 != 0 && iteration <= 25000)) continue;
+                }
+
+                auto bias_correction1_rcp = 1.0 / (1.0 - std::pow(beta1, state.step_count));
+                auto bias_correction2_sqrt_rcp = 1.0 / std::sqrt(1.0 - std::pow(beta2, state.step_count));
+
+                // Call the fused CUDA kernel from fastgs
+                fast_gs::optimizer::adam_step_wrapper(
+                    param,
+                    state.exp_avg,
+                    state.exp_avg_sq,
+                    param.grad(),
+                    static_cast<float>(lr),
+                    static_cast<float>(beta1),
+                    static_cast<float>(beta2),
+                    static_cast<float>(eps),
+                    static_cast<float>(bias_correction1_rcp),
+                    static_cast<float>(bias_correction2_sqrt_rcp)
+                );
+            }
+        }
+    }
+
+    // Based on https://github.com/pytorch/pytorch/blob/ee343ce60ceb449da09d229db25fa9d425d85a4b/torch/csrc/api/src/optim/optimizer.cpp#L122
+    void FusedAdam::zero_grad(bool set_to_none, int iteration) {
+        if constexpr (SKIP_SH_STEPS) {
+            int i = 0; // HACK: counter to track what Gaussian parameter we are on
+            for (auto& group : param_groups()) {
+                ++i;
+                for (auto& p : group.params()) {
+                    // We want to keep accumulating if the optimizer step was skipped
+                    if (i == 3 && (iteration % 2 != 0 && iteration <= 25000)) continue;
+                    if (p.mutable_grad().defined()) {
+                        p.mutable_grad().detach_();
+                        if (set_to_none)
+                            p.mutable_grad().reset();
+                        else
+                            p.mutable_grad().zero_();
+                    }
+                }
+            }
+        } else Optimizer::zero_grad(set_to_none);
+    }
+
+} // namespace gs

--- a/src/image_io.cpp
+++ b/src/image_io.cpp
@@ -12,6 +12,15 @@
 #include <iostream>
 #include <vector>
 
+std::tuple<int, int, int>
+get_image_info(std::filesystem::path p) {
+    int w, h, c;
+    int result = stbi_info(p.string().c_str(), &w, &h, &c);
+    if (!result)
+        throw std::runtime_error("stbi_info failed: " + p.string() + " : " + stbi_failure_reason());
+    return {w, h, c};
+}
+
 // Existing implementations...
 std::tuple<unsigned char*, int, int, int>
 load_image(std::filesystem::path p, int res_div) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,9 +7,24 @@
 #include <iostream>
 #include <memory>
 #include <thread>
+#include <c10/cuda/CUDAAllocatorConfig.h>
 
 int main(int argc, char* argv[]) {
     try {
+
+        //----------------------------------------------------------------------
+        // 0. Set CUDA caching allocator settings to avoid fragmentation issues
+        // This avoids the need to repeatedly call emptyCache() after
+        // densification steps. We manually call the proper function here
+        // instead of setting the environment variable hoping that this then
+        // also works on Windows. Setting the environment variable using
+        // setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True", 1);
+        // would work on Linux but not on Windows, so we use the C++ API.
+        // Should this break in the future, we can always revert to the old
+        // approach of calling emptyCache() after each densification step.
+        //----------------------------------------------------------------------
+        c10::cuda::CUDACachingAllocator::setAllocatorSettings("expandable_segments:True");
+
         //----------------------------------------------------------------------
         // 1. Parse arguments and load parameters in one step
         //----------------------------------------------------------------------

--- a/src/mcmc.cpp
+++ b/src/mcmc.cpp
@@ -16,6 +16,9 @@ void MCMC::ExponentialLR::step() {
         if (auto* selective_adam_options = dynamic_cast<gs::SelectiveAdam::Options*>(&group.options())) {
             double current_lr = selective_adam_options->lr();
             selective_adam_options->lr(current_lr * gamma_);
+        } else if (auto* fused_adam_options = dynamic_cast<gs::FusedAdam::Options*>(&group.options())) {
+            double current_lr = fused_adam_options->lr();
+            fused_adam_options->lr(current_lr * gamma_);
         } else if (auto* adam_options = dynamic_cast<torch::optim::AdamOptions*>(&group.options())) {
             double current_lr = adam_options->lr();
             adam_options->lr(current_lr * gamma_);
@@ -26,6 +29,9 @@ void MCMC::ExponentialLR::step() {
             if (auto* selective_adam_options = dynamic_cast<gs::SelectiveAdam::Options*>(&group.options())) {
                 double current_lr = selective_adam_options->lr();
                 selective_adam_options->lr(current_lr * gamma_);
+            } else if (auto* fused_adam_options = dynamic_cast<gs::FusedAdam::Options*>(&group.options())) {
+                double current_lr = fused_adam_options->lr();
+                fused_adam_options->lr(current_lr * gamma_);
             } else if (auto* adam_options = dynamic_cast<torch::optim::AdamOptions*>(&group.options())) {
                 double current_lr = adam_options->lr();
                 adam_options->lr(current_lr * gamma_);
@@ -117,6 +123,14 @@ void MCMC::update_optimizer_for_relocate(torch::optim::Optimizer* optimizer,
         if (selective_adam_state->max_exp_avg_sq.defined()) {
             selective_adam_state->max_exp_avg_sq.index_put_({sampled_indices}, 0);
         }
+    } else if (auto* fused_adam_state = dynamic_cast<gs::FusedAdam::AdamParamState*>(&param_state)) {
+        // FusedAdam
+        fused_adam_state->exp_avg.index_put_({sampled_indices}, 0);
+        fused_adam_state->exp_avg_sq.index_put_({sampled_indices}, 0);
+
+        if (fused_adam_state->max_exp_avg_sq.defined()) {
+            fused_adam_state->max_exp_avg_sq.index_put_({sampled_indices}, 0);
+        }
     }
 }
 
@@ -128,7 +142,8 @@ int MCMC::relocate_gs() {
         opacities = opacities.squeeze(-1);
     }
 
-    auto dead_mask = opacities <= _params->min_opacity;
+    auto rotation_raw = _splat_data.rotation_raw();
+    auto dead_mask = opacities <= _params->min_opacity | (rotation_raw * rotation_raw).sum(-1) < 1e-8f;
     auto dead_indices = dead_mask.nonzero().squeeze(-1);
     int n_dead = dead_indices.numel();
 
@@ -151,14 +166,13 @@ int MCMC::relocate_gs() {
     auto sampled_scales = _splat_data.get_scaling().index_select(0, sampled_idxs);
 
     // Count occurrences of each sampled index
-    auto ratios = torch::zeros({opacities.size(0)}, torch::kFloat32).to(torch::kCUDA);
-    ratios.index_add_(0, sampled_idxs, torch::ones_like(sampled_idxs, torch::kFloat32));
-    ratios = ratios.index_select(0, sampled_idxs) + 1;
+    auto ratios = torch::ones_like(opacities, torch::kInt32);
+    ratios.index_add_(0, sampled_idxs, torch::ones_like(sampled_idxs, torch::kInt32));
+    ratios = ratios.index_select(0, sampled_idxs).contiguous();
 
-    // IMPORTANT: Clamp and convert to int as in Python implementation
+    // IMPORTANT: Clamp as in Python implementation
     const int n_max = static_cast<int>(_binoms.size(0));
-    ratios = torch::clamp(ratios, 1, n_max);
-    ratios = ratios.to(torch::kInt32).contiguous(); // Convert to int!
+    ratios = torch::clamp_max_(ratios, n_max);
 
     // Call the CUDA relocation function from gsplat
     auto relocation_result = gsplat::relocation(
@@ -172,7 +186,7 @@ int MCMC::relocate_gs() {
     auto new_scales = std::get<1>(relocation_result);
 
     // Clamp new opacities
-    new_opacities = torch::clamp(new_opacities, _params->min_opacity, 1.0f - 1e-7f);
+    new_opacities = torch::clamp_(new_opacities, _params->min_opacity, 1.0f - 1e-7f);
 
     // Update parameters for sampled indices
     // Handle opacity shape properly
@@ -358,6 +372,37 @@ int MCMC::add_new_gs() {
                 }
 
                 saved_states.push_back(std::move(new_state));
+            } else if (auto* fused_adam_state = dynamic_cast<gs::FusedAdam::AdamParamState*>(state_it->second.get())) {
+                // FusedAdam state
+                torch::IntArrayRef new_shape;
+                if (i == 0)
+                    new_shape = new_means.sizes();
+                else if (i == 1)
+                    new_shape = new_sh0.sizes();
+                else if (i == 2)
+                    new_shape = new_shN.sizes();
+                else if (i == 3)
+                    new_shape = new_scaling.sizes();
+                else if (i == 4)
+                    new_shape = new_rotation.sizes();
+                else
+                    new_shape = new_opacity.sizes();
+
+                auto zeros_to_add = torch::zeros(new_shape, fused_adam_state->exp_avg.options());
+                auto new_exp_avg = torch::cat({fused_adam_state->exp_avg, zeros_to_add}, 0);
+                auto new_exp_avg_sq = torch::cat({fused_adam_state->exp_avg_sq, zeros_to_add}, 0);
+
+                // Create new state
+                auto new_state = std::make_unique<gs::FusedAdam::AdamParamState>();
+                new_state->step_count = fused_adam_state->step_count;
+                new_state->exp_avg = new_exp_avg;
+                new_state->exp_avg_sq = new_exp_avg_sq;
+                if (fused_adam_state->max_exp_avg_sq.defined()) {
+                    auto new_max_exp_avg_sq = torch::cat({fused_adam_state->max_exp_avg_sq, zeros_to_add}, 0);
+                    new_state->max_exp_avg_sq = new_max_exp_avg_sq;
+                }
+
+                saved_states.push_back(std::move(new_state));
             } else {
                 saved_states.push_back(nullptr);
             }
@@ -393,31 +438,7 @@ int MCMC::add_new_gs() {
 }
 
 void MCMC::inject_noise() {
-    // Get opacities and handle both [N] and [N, 1] shapes
     torch::NoGradGuard no_grad;
-
-    auto opacities = _splat_data.get_opacity();
-    if (opacities.dim() == 2 && opacities.size(1) == 1) {
-        opacities = opacities.squeeze(-1);
-    }
-
-    auto scales = _splat_data.get_scaling();
-    auto quats = _splat_data.get_rotation();
-
-    // Use gsplat's quat_scale_to_covar_preci function
-    auto covar_result = gsplat::quat_scale_to_covar_preci_fwd(
-        quats,
-        scales,
-        true,  // compute_covar
-        false, // compute_preci
-        false  // triu
-    );
-    auto covars = std::get<0>(covar_result); // [N, 3, 3]
-
-    // Opacity sigmoid function: 1 / (1 + exp(-k * (x - x0)))
-    const float k = 100.0f;
-    const float x0 = 0.995f;
-    auto op_sigmoid = 1.0f / (1.0f + torch::exp(-k * ((1.0f - opacities) - x0)));
 
     // Get current learning rate from optimizer (after scheduler has updated it)
     float current_lr = 0.0f;
@@ -426,16 +447,21 @@ void MCMC::inject_noise() {
         current_lr = static_cast<float>(adam_options->lr());
     } else if (auto* selective_adam_options = dynamic_cast<gs::SelectiveAdam::Options*>(&group.options())) {
         current_lr = static_cast<float>(selective_adam_options->lr());
+    } else if (auto* fused_adam_options = dynamic_cast<gs::FusedAdam::Options*>(&group.options())) {
+        current_lr = static_cast<float>(fused_adam_options->lr());
     }
+    current_lr *= _noise_lr;
 
     // Generate noise
-    auto noise = torch::randn_like(_splat_data.means()) * op_sigmoid.unsqueeze(-1) * current_lr * _noise_lr;
+    auto noise = torch::randn_like(_splat_data.means());
 
-    // Transform noise by covariance
-    noise = torch::bmm(covars, noise.unsqueeze(-1)).squeeze(-1);
-
-    // Add noise to positions
-    _splat_data.means().add_(noise);
+    gsplat::add_noise(
+        _splat_data.opacity_raw(),
+        _splat_data.scaling_raw(),
+        _splat_data.rotation_raw(),
+        noise,
+        _splat_data.means(),
+        current_lr);
 }
 
 void MCMC::post_backward(int iter, gs::RenderOutput& render_output) {
@@ -458,7 +484,7 @@ void MCMC::post_backward(int iter, gs::RenderOutput& render_output) {
         // Add new Gaussians
         add_new_gs();
 
-        c10::cuda::CUDACachingAllocator::emptyCache();
+        // c10::cuda::CUDACachingAllocator::emptyCache(); // Can be needed on some systems (see main.cpp)
     }
 
     // Inject noise to positions
@@ -474,10 +500,17 @@ void MCMC::step(int iter) {
             } else {
                 _optimizer->step();
             }
+            _optimizer->zero_grad(true);
         } else {
-            _optimizer->step();
+            auto* fused_adam = dynamic_cast<gs::FusedAdam*>(_optimizer.get());
+            if (fused_adam) {
+                fused_adam->step(iter);
+                fused_adam->zero_grad(true, iter);
+            } else {
+                _optimizer->step();
+                _optimizer->zero_grad(true);
+            }
         }
-        _optimizer->zero_grad(true);
         _scheduler->step();
     }
 }
@@ -537,28 +570,54 @@ void MCMC::initialize(const gs::param::OptimizationParameters& optimParams) {
         global_options->eps(1e-15);
         _optimizer = std::make_unique<gs::SelectiveAdam>(std::move(groups), std::move(global_options));
     } else {
-        using torch::optim::AdamOptions;
+        std::cout << "Using FusedAdam optimizer" << std::endl;
+
+        using Options = gs::FusedAdam::Options;
         std::vector<torch::optim::OptimizerParamGroup> groups;
 
-        // Calculate initial learning rate for position
-        groups.emplace_back(torch::optim::OptimizerParamGroup({_splat_data.means()},
-                                                              std::make_unique<AdamOptions>(_params->means_lr * _splat_data.get_scene_scale())));
-        groups.emplace_back(torch::optim::OptimizerParamGroup({_splat_data.sh0()},
-                                                              std::make_unique<AdamOptions>(_params->shs_lr)));
-        groups.emplace_back(torch::optim::OptimizerParamGroup({_splat_data.shN()},
-                                                              std::make_unique<AdamOptions>(_params->shs_lr / 20.f)));
-        groups.emplace_back(torch::optim::OptimizerParamGroup({_splat_data.scaling_raw()},
-                                                              std::make_unique<AdamOptions>(_params->scaling_lr)));
-        groups.emplace_back(torch::optim::OptimizerParamGroup({_splat_data.rotation_raw()},
-                                                              std::make_unique<AdamOptions>(_params->rotation_lr)));
-        groups.emplace_back(torch::optim::OptimizerParamGroup({_splat_data.opacity_raw()},
-                                                              std::make_unique<AdamOptions>(_params->opacity_lr)));
+        // Create groups with proper unique_ptr<Options>
+        auto add_param_group = [&groups](const torch::Tensor& param, double lr) {
+            auto options = std::make_unique<Options>(lr);
+            options->eps(1e-15).betas(std::make_tuple(0.9, 0.999));
+            groups.emplace_back(
+                std::vector<torch::Tensor>{param},
+                std::unique_ptr<torch::optim::OptimizerOptions>(std::move(options)));
+        };
 
-        for (auto& g : groups)
-            static_cast<AdamOptions&>(g.options()).eps(1e-15);
+        add_param_group(_splat_data.means(), _params->means_lr * _splat_data.get_scene_scale());
+        add_param_group(_splat_data.sh0(), _params->shs_lr);
+        add_param_group(_splat_data.shN(), _params->shs_lr / 20.f);
+        add_param_group(_splat_data.scaling_raw(), _params->scaling_lr);
+        add_param_group(_splat_data.rotation_raw(), _params->rotation_lr);
+        add_param_group(_splat_data.opacity_raw(), _params->opacity_lr);
 
-        _optimizer = std::make_unique<torch::optim::Adam>(groups, AdamOptions(0.f).eps(1e-15));
+        auto global_options = std::make_unique<Options>(0.f);
+        global_options->eps(1e-15);
+        _optimizer = std::make_unique<gs::FusedAdam>(std::move(groups), std::move(global_options));
     }
+    // } else {
+    //     using torch::optim::AdamOptions;
+    //     std::vector<torch::optim::OptimizerParamGroup> groups;
+
+    //     // Calculate initial learning rate for position
+    //     groups.emplace_back(torch::optim::OptimizerParamGroup({_splat_data.means()},
+    //                                                           std::make_unique<AdamOptions>(_params->means_lr * _splat_data.get_scene_scale())));
+    //     groups.emplace_back(torch::optim::OptimizerParamGroup({_splat_data.sh0()},
+    //                                                           std::make_unique<AdamOptions>(_params->shs_lr)));
+    //     groups.emplace_back(torch::optim::OptimizerParamGroup({_splat_data.shN()},
+    //                                                           std::make_unique<AdamOptions>(_params->shs_lr / 20.f)));
+    //     groups.emplace_back(torch::optim::OptimizerParamGroup({_splat_data.scaling_raw()},
+    //                                                           std::make_unique<AdamOptions>(_params->scaling_lr)));
+    //     groups.emplace_back(torch::optim::OptimizerParamGroup({_splat_data.rotation_raw()},
+    //                                                           std::make_unique<AdamOptions>(_params->rotation_lr)));
+    //     groups.emplace_back(torch::optim::OptimizerParamGroup({_splat_data.opacity_raw()},
+    //                                                           std::make_unique<AdamOptions>(_params->opacity_lr)));
+
+    //     for (auto& g : groups)
+    //         static_cast<AdamOptions&>(g.options()).eps(1e-15);
+
+    //     _optimizer = std::make_unique<torch::optim::Adam>(groups, AdamOptions(0.f).eps(1e-15));
+    // }
 
     // Initialize exponential scheduler
     // Python: gamma = 0.01^(1/max_steps)

--- a/src/splat_data.cpp
+++ b/src/splat_data.cpp
@@ -400,5 +400,14 @@ SplatData SplatData::init_model_from_pointcloud(const gs::param::TrainingParamet
     std::cout << "  - sh0 shape: " << sh0.sizes() << std::endl;
     std::cout << "  - shN shape: " << shN.sizes() << std::endl;
 
-    return SplatData(params.optimization.sh_degree, means, sh0, shN, scaling, rotation, opacity, scene_scale);
+    return SplatData(
+        params.optimization.sh_degree,
+        means.contiguous(),
+        sh0.contiguous(),
+        shN.contiguous(),
+        scaling.contiguous(),
+        rotation.contiguous(),
+        opacity.contiguous(),
+        scene_scale
+    );
 }


### PR DESCRIPTION
This is a solution for [Issue #135](https://github.com/MrNeRF/gaussian-splatting-cuda/issues/135).
It implements improvements that reduce the training from the original 49m 50s to **20m 30s**, a speedup by over **2.4x**.
To get the time below 20 minutes, I also added an *optional* trick that sacrifices some quality to get the time down to *19m 27s*.

## Changes

The key changes can be summarized as follows:

### New Rasterizer
- Instead of the modular gsplat implementation, the new implementation tries to use as few CUDA kernels as possible.
- I redid all the math for the forward and backward pass to skip all unnecessary computations.
- All activation functions of the Gaussians' parameters are fused into the respective kernels of the forward and backward pass.
- I implemented an improved version of the kernel for the blending backward pass based on Taming 3DGS.
- I separated the sorting into depth and tile sorting passes similar to how it is done in Splatshop.
- I integrated tile-based culling and load balancing based on StopThePop.
- Also see `fastgs/rasterization/README.md`

### MCMC Densification
- After every training iteration, MCMC adds noise to the position of each Gaussian. I fused the required operations into a single kernel.
- The functions for adding and relocating Gaussians could be fused too, but because they do not happen that often during training, the benefit would be small. Therefore, I did not do so and only fixed a few inefficiencies in the libtorch implementation.
- Gaussians are now also "dead" when the quaternion used to represent their rotation has a squared norm below `1e-8` as optimization and rendering would then be numerically unstable anyway. The new rasterizer also culls such Gaussians during training.
- Like most 3DGS implementations, the old implementation used to call the libtorch equivalent of `torch.cuda.empty_cache()` after every densification step to solve memory fragmentation issues. This slightly slows down training as temporary memory is first freed and then reallocated. Enabling the torch memory allocator's setting `expandable_segments:True` allows to get rid of this.
- I removed the `abs()` calls in the opacity and scale regularization losses as they are unnecessary because the Gaussians' opacity and scale are always positive after applying the respective activations.

### Optimizer
- The libtorch Adam implementation is slow because it launches all operations for each update step as separate CUDA kernels. I implemented a fused version of the Adam optimizer step that is significantly faster.
- During the first 1000 iterations, the higher-degree SH coefficients will not be used and therefore always have zero gradients. Therefore, the optimizer step for those can be skipped for a small speedup.
- (optional) Between iteration 1000 and 25000, the expensive update for higher-degree SH coefficients can be batched over two iterations to achieve a small speed up. This is disabled by default as it seems to slightly reduce quality in my tests.

### Data Loading
- The torch dataloader was re-created after every epoch. Now only the random sampler is reset, which avoids unnecessary overhead.
- Image normalization to the [0, 1] range was done on the CPU. Doing it after uploading to the GPU is much faster.
- Images were always loaded from disk, which is actually not that bad with a torch dataloader that uses multiple worker threads, but it has some overhead. Now, heuristics are used to determine whether the dataset fits into GPU memory. If yes, images are cached in VRAM.
- Since the VRAM needed for storing the view matrices and camera positions for all views is negligible, they are now precomputed and stored in VRAM. Example: 10k views -> 0.76 MB (could be lower as I store the full 4x4 view matrix instead of just the relevant 3x4 part)

## Evaluation

Timings are quite consistent across runs as long as one does not touch the PC during benchmarking.
```
=========================================
BENCHMARK SUMMARY
=========================================
garden         : 00h 02m 28s
bicycle        : 00h 02m 14s
stump          : 00h 02m 20s
bonsai         : 00h 03m 17s
counter        : 00h 03m 35s
kitchen        : 00h 03m 42s
room           : 00h 02m 54s
-----------------------------------------
Total time: 0h 20m 30s
=========================================
```
With the optional SH trick enabled, training is slightly faster and the total is below 20 minutes:
```
=========================================
BENCHMARK SUMMARY
=========================================
garden         : 00h 02m 18s
bicycle        : 00h 02m 06s
stump          : 00h 02m 11s
bonsai         : 00h 03m 07s
counter        : 00h 03m 25s
kitchen        : 00h 03m 35s
room           : 00h 02m 45s
-----------------------------------------
Total time: 0h 19m 27s
=========================================
```

Here are the average quality metrics that I got with the original implementation and the new one without and with the optional SH trick enabled.
Note that metric computation still uses gsplat to render the images. This highlights that the new rasterizer used during training is not required during inference to obtain high quality.

| Version              | PSNR      | SSIM     | LPIPS    |
|----------------------|-----------|----------| -------- |
| original             | 29.235601 | 0.879749 | 0.227879 |
| solution             | 29.277397 | 0.879477 | 0.228021 |
| solution w/ SH trick | 29.226835 | 0.879472 | 0.228022 |

I spent a lot of time on making sure the new implementation does not reduce quality.
Note that the results in this table do not confirm that the new implementation is strictly better than the original one.
There are small differences in terms of how things are computed in a numerically stable manner in the rasterizer.
However, this did not make a measurable difference in practice.
The main problem when repeatedly testing both the original and the new implementation is that metrics fluctuate between runs making it impossible to tell which implementation achieves better quality.