### PR TITLE
Bounty submission: 70% speedup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ configure_file(
 )
 
 add_subdirectory(gsplat)
+add_subdirectory(taminggs)
 
 # =============================================================================
 # HOST LIBRARY - Compiled with g++ (fast!)
@@ -89,6 +90,8 @@ set(HOST_SOURCES
         src/external/tinyply.cpp
         src/bilateral_grid.cpp
         src/selective_adam.cpp
+        src/rasterizer_tgs.cpp
+        src/rasterizer_tgs_autograd.cpp
 )
 
 add_library(gaussian_host STATIC ${HOST_SOURCES})
@@ -98,8 +101,9 @@ target_include_directories(gaussian_host
         PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         ${CMAKE_CURRENT_BINARY_DIR}/include  # For generated config.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/gsplat  # Add gsplat headers
-        ${CUDAToolkit_INCLUDE_DIRS}         # Add CUDA headers for interop
+        ${CMAKE_CURRENT_SOURCE_DIR}/gsplat   # Add gsplat headers
+        ${CMAKE_CURRENT_SOURCE_DIR}/taminggs # Add taminggs headers
+        ${CUDAToolkit_INCLUDE_DIRS}          # Add CUDA headers for interop
         PRIVATE
         ${Python3_INCLUDE_DIRS}
         ${OPENGL_INCLUDE_DIRS}
@@ -116,9 +120,10 @@ target_link_libraries(gaussian_host
         Threads::Threads
         taywee::args
         Python3::Python
-        gsplat_backend  # Link to gsplat
+        gsplat_backend   # Link to gsplat
+        taminggs_backend # Link to tamings
         ${OPENGL_LIBRARIES}
-        CUDA::cudart    # Add CUDA runtime for interop
+        CUDA::cudart     # Add CUDA runtime for interop
 )
 if(UNIX)
     target_link_libraries(gaussian_host PUBLIC dl)
@@ -151,6 +156,8 @@ set(KERNEL_SOURCES
         kernels/bilateral_grid_forward.cu
         kernels/bilateral_grid_backward.cu
         kernels/bilateral_grid_tv.cu
+        kernels/lanczos.cu
+        kernels/tgs_adam.cu
 )
 
 # Add CUDA-OpenGL interop kernels if supported
@@ -251,6 +258,7 @@ target_include_directories(${PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         ${CMAKE_CURRENT_BINARY_DIR}/include  # For generated config.h
         ${CMAKE_CURRENT_SOURCE_DIR}/gsplat
+        ${CMAKE_CURRENT_SOURCE_DIR}/taminggs
         ${Python3_INCLUDE_DIRS}
         ${CUDAToolkit_INCLUDE_DIRS}
         ${OPENGL_INCLUDE_DIRS}
@@ -261,6 +269,7 @@ set(MAIN_LINK_LIBRARIES
         gaussian_host
         gaussian_kernels
         gsplat_backend
+        taminggs_backend
         Python3::Python
         ${OPENGL_LIBRARIES}
         CUDA::cudart
@@ -330,6 +339,7 @@ endfunction()
 configure_build_type(gaussian_host)
 configure_build_type(gaussian_kernels)
 configure_build_type(gsplat_backend)
+configure_build_type(taminggs_backend)
 if(CUDA_GL_INTEROP_FOUND AND TARGET gaussian_visualizer)
     configure_build_type(gaussian_visualizer)
 endif()
@@ -372,6 +382,7 @@ if(BUILD_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/include
             ${CMAKE_CURRENT_BINARY_DIR}/include  # For generated config.h
             ${CMAKE_CURRENT_SOURCE_DIR}/gsplat
+            ${CMAKE_CURRENT_SOURCE_DIR}/taminggs
             ${CMAKE_CURRENT_SOURCE_DIR}/tests
             ${Python3_INCLUDE_DIRS}
             ${CUDAToolkit_INCLUDE_DIRS}
@@ -382,6 +393,7 @@ if(BUILD_TESTS)
             gaussian_host
             gaussian_kernels
             gsplat_backend
+            taminggs_backend
             GTest::gtest
             GTest::gtest_main
             Python3::Python

--- a/include/core/camera.hpp
+++ b/include/core/camera.hpp
@@ -29,10 +29,22 @@ public:
 
     // Load image from disk and return it
     torch::Tensor load_and_get_image(int resolution = -1);
+    torch::Tensor load_image_cache(int resolution = -1);
+
+    void set_image_height(const int& height) { _image_height = height;}
+    void set_image_width(const int& width) { _image_width = width; }
 
     // Accessors - now return const references to avoid copies
     const torch::Tensor& world_view_transform() const {
         return _world_view_transform;
+    }
+
+    const torch::Tensor& projmat() const {
+        return _projmat;
+    }
+
+    const torch::Tensor& campos() const {
+        return _campos;
     }
 
     torch::Tensor K() const;
@@ -41,14 +53,22 @@ public:
     int image_width() const noexcept { return _image_width; }
     float FoVx() const noexcept { return _FoVx; }
     float FoVy() const noexcept { return _FoVy; }
+    float tanfovx() const noexcept { return _tanfovx; }
+    float tanfovy() const noexcept { return _tanfovy; }
     const std::string& image_name() const noexcept { return _image_name; }
     int uid() const noexcept { return _uid; }
+
+    // Variables to determine where to cache the image tensors
+    bool cache_on_gpu = false;
+    bool cache_on_cpu = false;
 
 private:
     // IDs
     int _uid = -1;
     float _FoVx = 0.f;
     float _FoVy = 0.f;
+    float _tanfovx = 0.f;
+    float _tanfovy = 0.f;
 
     // Image info
     std::string _image_name;
@@ -58,4 +78,9 @@ private:
 
     // GPU tensors (computed on demand)
     torch::Tensor _world_view_transform;
+    torch::Tensor _projmat;
+    torch::Tensor _campos;
+
+    // Dynamically cache image tensor
+    torch::Tensor _image_cache;
 };

--- a/include/core/dataset.hpp
+++ b/include/core/dataset.hpp
@@ -6,6 +6,50 @@
 #include <memory>
 #include <torch/torch.h>
 #include <vector>
+#include <cuda_runtime.h>
+#include <fstream>
+
+constexpr double   kCapFraction = 0.80;
+
+struct MemInfo { uint64_t free_b, total_b; };
+
+inline MemInfo gpu_mem_info() {
+    size_t free_b = 0, total_b = 0;
+    auto e = cudaMemGetInfo(&free_b, &total_b);
+    if (e != cudaSuccess) throw std::runtime_error(cudaGetErrorString(e));
+    return MemInfo{ static_cast<uint64_t>(free_b), static_cast<uint64_t>(total_b) };
+}
+
+inline MemInfo cpu_mem_info() {
+    std::ifstream f("/proc/meminfo");
+    if (!f) throw std::runtime_error("Cannot open /proc/meminfo");
+    uint64_t mem_total_kb = 0, mem_avail_kb = 0; std::string k, unit; uint64_t v;
+    std::string line;
+    while (std::getline(f, line)) {
+        std::istringstream iss(line);
+        if (iss >> k >> v >> unit) {
+            if (k == "MemTotal:")      mem_total_kb = v;
+            else if (k == "MemAvailable:") mem_avail_kb = v;
+        }
+    }
+    if (!mem_total_kb || !mem_avail_kb)
+        throw std::runtime_error("Failed to parse MemTotal/MemAvailable");
+    return MemInfo{ mem_avail_kb * 1024ULL, mem_total_kb * 1024ULL };
+}
+
+// Safe budget left to use if we cap at cap_fraction of total.
+// device_used_now = total - free.
+// Budget_now = max(0, cap_fraction*total - device_used_now).
+inline uint64_t budget_left_now(const MemInfo& m, double cap_fraction) {
+    const long double cap = cap_fraction * static_cast<long double>(m.total_b);
+    const long double used = static_cast<long double>(m.total_b - m.free_b);
+    long double left = cap - used;
+    return left > 0 ? static_cast<uint64_t>(left) : 0ULL;
+}
+
+inline uint64_t img_bytes_float_rgb(uint32_t w, uint32_t h) {
+    return static_cast<uint64_t>(w) * h * 3ULL * sizeof(float);
+}
 
 // Camera with loaded image
 struct CameraWithImage {
@@ -60,7 +104,7 @@ public:
         auto& cam = _cameras[camera_idx];
 
         // Just load image - no prefetching since indices are random
-        torch::Tensor image = cam->load_and_get_image(_datasetConfig.resolution);
+        torch::Tensor image = cam->load_image_cache(_datasetConfig.resolution);
 
         // Return camera pointer and image
         return {{cam.get(), std::move(image)}, torch::empty({})};
@@ -111,6 +155,31 @@ inline std::tuple<std::shared_ptr<CameraDataset>, torch::Tensor> create_dataset_
             info._width,
             info._height,
             static_cast<int>(i));
+
+
+        const uint64_t bytes = img_bytes_float_rgb(info._width, info._height);
+
+        // Re check mem after each iteration
+        MemInfo g = gpu_mem_info();
+        MemInfo c = cpu_mem_info();
+
+        uint64_t gpu_left_now = budget_left_now(g, kCapFraction);
+        uint64_t cpu_left_now = budget_left_now(c, kCapFraction);
+        
+        // Decide where to cache the image based on available memory
+        if (bytes <= gpu_left_now) {
+            // Use GPU cache if available
+            cam->cache_on_gpu = true;
+            cam->cache_on_cpu = false;
+        } else if (bytes <= cpu_left_now) {
+            // Use CPU cache if GPU is not available or full
+            cam->cache_on_gpu = false;
+            cam->cache_on_cpu = true;
+        } else {
+            // stream from disk
+            cam->cache_on_gpu = false;
+            cam->cache_on_cpu = false;
+        }
 
         cameras.push_back(std::move(cam));
     }

--- a/include/core/istrategy.hpp
+++ b/include/core/istrategy.hpp
@@ -12,8 +12,8 @@ public:
     virtual ~IStrategy() = default;
 
     virtual void initialize(const gs::param::OptimizationParameters& optimParams) = 0;
-    virtual void post_backward(int iter, gs::RenderOutput& render_output) = 0;
-    virtual void step(int iter) = 0;
+    virtual void post_backward(int iter, gs::RenderOutput& render_output, float reso) = 0;
+    virtual void step(int iter, float reso) = 0;
     virtual bool is_refining(int iter) const = 0;
     // Get the underlying Gaussian model for rendering
     virtual SplatData& get_model() = 0;

--- a/include/core/mcmc.hpp
+++ b/include/core/mcmc.hpp
@@ -17,9 +17,9 @@ public:
 
     // IStrategy interface implementation
     void initialize(const gs::param::OptimizationParameters& optimParams) override;
-    void post_backward(int iter, gs::RenderOutput& render_output) override;
+    void post_backward(int iter, gs::RenderOutput& render_output, float reso) override;
     bool is_refining(int iter) const override;
-    void step(int iter) override;
+    void step(int iter, float reso) override;
     SplatData& get_model() override { return _splat_data; }
     const SplatData& get_model() const override { return _splat_data; }
 
@@ -32,7 +32,7 @@ private:
               gamma_(gamma),
               param_group_index_(param_group_index) {}
 
-        void step();
+        void step(float reso);
 
     private:
         torch::optim::Optimizer& optimizer_;
@@ -43,7 +43,7 @@ private:
     // Helper functions
     torch::Tensor multinomial_sample(const torch::Tensor& weights, int n, bool replacement = true);
     int relocate_gs();
-    int add_new_gs();
+    int add_new_gs(int iter, float reso);
     void inject_noise();
     void update_optimizer_for_relocate(torch::optim::Optimizer* optimizer,
                                        const torch::Tensor& sampled_indices,
@@ -58,6 +58,7 @@ private:
 
     // MCMC specific parameters
     const float _noise_lr = 5e5;
+    int _Pinit;
 
     // State variables
     torch::Tensor _binoms;

--- a/include/core/parameters.hpp
+++ b/include/core/parameters.hpp
@@ -45,6 +45,9 @@ namespace gs {
 
             int steps_scaler = 1;
             bool selective_adam = false; // Use Selective Adam optimizer
+            int update_shN_after_every = 16; // Update shN every N steps
+            int do_batch_update_after = 16; // Perform batch updates after N steps
+            bool use_visibility_mask = false; // Use visibility mask in selective adam
         };
 
         struct DatasetConfig {

--- a/include/core/rasterizer_tgs.hpp
+++ b/include/core/rasterizer_tgs.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "core/rasterizer.hpp"
+#include "Ops.h"
+#include "core/camera.hpp"
+#include "core/splat_data.hpp"
+#include <torch/torch.h>
+
+namespace tgs {
+
+    gs::RenderOutput rasterize(
+        Camera& viewpoint_camera,
+        const SplatData& gaussian_model,
+        torch::Tensor& bg_color,
+        float scaling_modifier/*=1*/,
+        bool packed/*=false*/,
+        bool antialiased/*=false*/,
+        gs::RenderMode render_mode);
+
+}

--- a/include/core/rasterizer_tgs_autograd.hpp
+++ b/include/core/rasterizer_tgs_autograd.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "Ops.h"
+#include "core/camera.hpp"
+#include "core/splat_data.hpp"
+#include <torch/torch.h>
+
+namespace tgs {
+
+    class RasterizationFunction : public torch::autograd::Function<RasterizationFunction> {
+    public:
+        static torch::autograd::variable_list forward(
+            torch::autograd::AutogradContext* ctx,
+            const torch::Tensor& means3D,
+            const torch::Tensor& sh0,
+            const torch::Tensor& shN,
+            const torch::Tensor& colors_precomp,
+            const torch::Tensor& opacities,
+            const torch::Tensor& scales,
+            const torch::Tensor& rotations,
+            const torch::Tensor& cov3Ds_precomp,
+            const torch::Tensor& viewmat,
+            const torch::Tensor& projmat,
+            const torch::Tensor& bg_color,
+            const torch::Tensor& campos,
+            const torch::Tensor& settings
+        );
+
+        static torch::autograd::tensor_list backward(
+            torch::autograd::AutogradContext* ctx,
+            torch::autograd::tensor_list grad_outputs
+        );
+    };
+
+}

--- a/include/core/splat_data.hpp
+++ b/include/core/splat_data.hpp
@@ -42,6 +42,8 @@ public:
     torch::Tensor get_rotation() const;
     torch::Tensor get_scaling() const;
     torch::Tensor get_shs() const;
+    torch::Tensor get_sh0() const;
+    torch::Tensor get_shN() const;
 
     // Simple inline getters
     inline int get_active_sh_degree() const { return _active_sh_degree; }

--- a/include/core/trainer.hpp
+++ b/include/core/trainer.hpp
@@ -58,7 +58,7 @@ namespace gs {
     private:
         // Protected method for processing a single training step
         // Returns true if training should continue
-        bool train_step(int iter, Camera* cam, torch::Tensor gt_image, RenderMode render_mode);
+        bool train_step(int iter, Camera* cam, torch::Tensor gt_image, RenderMode render_mode, float reso);
 
         // Protected method for computing loss
         torch::Tensor compute_loss(const RenderOutput& render_output,

--- a/include/kernels/lanczos.cuh
+++ b/include/kernels/lanczos.cuh
@@ -1,0 +1,17 @@
+/*
+Copyright (c) 2025 Youyu Chen
+SPDX-License-Identifier: MIT
+*/
+#pragma once
+#include <torch/extension.h>
+
+#define BLOCK_X 16
+#define BLOCK_Y 16
+#define NUM_CHANNELS 3
+
+torch::Tensor LanczosResampling(
+	const torch::Tensor &input, 
+	const int output_h, 
+	const int output_w, 
+	const int kernel_size
+);

--- a/include/kernels/tgs_adam.cuh
+++ b/include/kernels/tgs_adam.cuh
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+namespace at {
+class Tensor;
+}
+
+namespace taminggs {
+
+void fused_adam(
+    at::Tensor &param,                    // [N, ...]
+    const at::Tensor &param_grad,         // [N, ...]
+    at::Tensor &exp_avg,                  // [N, ...]
+    at::Tensor &exp_avg_sq,               // [N, ...]
+    const at::optional<at::Tensor> valid, // [N]
+    const float lr,
+    const float b1,
+    const float b2,
+    const float eps,
+    const int64_t step_size
+);
+
+}

--- a/kernels/lanczos.cu
+++ b/kernels/lanczos.cu
@@ -1,0 +1,153 @@
+/*
+Copyright (c) 2025 Youyu Chen
+SPDX-License-Identifier: MIT
+*/
+#include <math.h>
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <device_launch_parameters.h>
+
+#include "kernels/lanczos.cuh"
+
+namespace cg = cooperative_groups;
+
+namespace CUDA_LANCZOS {
+
+__device__ float sinc(const float x) {
+	if (fabs(x) < 1e-12) return 1.0f;
+	return sin(M_PI * x) / (M_PI * x);
+}
+
+__device__ float lanczos_kernel(const float x, const float a) {
+	if (x <= -a || x >= a) return 0.0f;
+	return sinc(x) * sinc(x / a);
+}
+
+__global__ void __launch_bounds__(BLOCK_X * BLOCK_Y)
+PreComputeCoef(
+	const int input_size, 
+	const int output_size, 
+	const int kernel_size, 
+	float* __restrict__ kernel_values
+) {
+	const auto block = cg::this_thread_block();
+	const uint32_t thread_idx = block.thread_index().x;
+	const uint32_t output_idx = block.group_index().x * BLOCK_X * BLOCK_Y + thread_idx;
+	const float output_ax = (float)output_idx;
+	const float scale = 1.0f * input_size / output_size;
+	const bool inside = output_idx < output_size;
+
+	if (!inside) return;
+
+	const float center = (output_ax + 0.5f) * scale;
+	const int2 box = {
+		max((int)(center - kernel_size * scale + 0.5f), 0), 
+		min((int)(center + kernel_size * scale + 0.5f), input_size)
+	};
+
+	const uint32_t offset = output_idx * (uint32_t)(kernel_size * scale * 2 + 1 + 0.5f);
+	float norm = 0.0f;
+	for (int i = box.x; i < box.y; i++) {
+		float value = lanczos_kernel((i + 0.5f - center) / scale, kernel_size);
+		kernel_values[offset + i - box.x] = value;
+		norm += value;
+	}
+	for (int i = box.x; i < box.y; i++) {
+		kernel_values[offset + i - box.x] /= norm;
+	}
+}
+
+template <uint32_t CHANNELS>
+__global__ void __launch_bounds__(BLOCK_X * BLOCK_Y)
+LanczosResampleCUDA(
+	const int input_h, const int input_w, 
+	const int output_h, const int output_w, 
+	const int kernel_size, 
+	const float* __restrict__ pre_coef_x, 
+	const float* __restrict__ pre_coef_y, 
+	const float* __restrict__ input, 
+	float* __restrict__ output
+) {
+	const auto block = cg::this_thread_block();
+	const uint32_t thread_idx_x = block.thread_index().x;
+	const uint32_t thread_idx_y = block.thread_index().y;
+	const uint2 pix = {
+		block.group_index().x * BLOCK_X + thread_idx_x, 
+		block.group_index().y * BLOCK_Y + thread_idx_y
+	};
+	const uint32_t pix_id = output_w * pix.y + pix.x;
+	const float2 pixf = { (float)pix.x, (float)pix.y };
+	float scale_h = 1.0f * input_h / output_h, scale_w = 1.0f * input_w / output_w;
+
+	const bool inside = (pix.x < output_w && pix.y < output_h);
+
+	if (!inside) return;
+
+	const float2 center = { (pixf.x + 0.5f) * scale_w, (pixf.y + 0.5f) * scale_h };
+
+	const int2 LU = {
+		max((int)(center.x - kernel_size * scale_w + 0.5f), 0), 
+		max((int)(center.y - kernel_size * scale_h + 0.5f), 0)
+	};
+	const int2 RD = {
+		min((int)(center.x + kernel_size * scale_w + 0.5f), input_w), 
+		min((int)(center.y + kernel_size * scale_h + 0.5f), input_h)
+	};
+
+	uint32_t coef_offset_step_y = (uint32_t)(kernel_size * scale_h * 2 + 1 + 0.5f);
+	uint32_t coef_offset_step_x = (uint32_t)(kernel_size * scale_w * 2 + 1 + 0.5f);
+	for (int y = LU.y; y < RD.y; y++) {
+		float kernel_value_y = pre_coef_y[pix.y * coef_offset_step_y + y - LU.y];
+		for (int x = LU.x; x < RD.x; x++) {
+			uint32_t input_pix_id = input_w * y + x;
+			float kernel_value_x = pre_coef_x[pix.x * coef_offset_step_x + x - LU.x];
+			float kernel_value = kernel_value_y * kernel_value_x;
+			for (int ch = 0; ch < CHANNELS; ch++)
+				output[pix_id * 3 + ch] += input[input_pix_id * 3 + ch] * kernel_value;
+		}
+	}
+}
+
+}
+
+torch::Tensor LanczosResampling(
+	const torch::Tensor &input, 
+	const int output_h, 
+	const int output_w, 
+	const int kernel_size
+) {
+	const int input_h = input.size(0), input_w = input.size(1);
+	uint32_t channels = input.size(2);
+	torch::Tensor output = torch::zeros({output_h, output_w, channels}, input.options());
+
+	const uint32_t offset_step_x = (uint32_t)(kernel_size * (1.0 * input_w / output_w) * 2 + 1 + 0.5f);
+	const uint32_t offset_step_y = (uint32_t)(kernel_size * (1.0 * input_h / output_h) * 2 + 1 + 0.5f);
+	float* coef_x;
+	float* coef_y;
+	cudaMalloc(&coef_x, sizeof(float) * output_w * offset_step_x);
+	cudaMalloc(&coef_y, sizeof(float) * output_h * offset_step_y);
+
+	CUDA_LANCZOS::PreComputeCoef<<<(output_w + BLOCK_X * BLOCK_Y - 1) / (BLOCK_X * BLOCK_Y), BLOCK_X * BLOCK_Y>>>(
+		input_w, output_w, kernel_size, coef_x);
+	CUDA_LANCZOS::PreComputeCoef<<<(output_h + BLOCK_X * BLOCK_Y - 1) / (BLOCK_X * BLOCK_Y), BLOCK_X * BLOCK_Y>>>(
+		input_h, output_h, kernel_size, coef_y);
+	
+	const dim3 tile_grid((output_w + BLOCK_X - 1) / BLOCK_X, (output_h + BLOCK_Y - 1) / BLOCK_Y);
+	const dim3 block(BLOCK_X, BLOCK_Y, 1);
+	CUDA_LANCZOS::LanczosResampleCUDA<NUM_CHANNELS><<<tile_grid, block>>>(
+		input_h, input_w, 
+		output_h, output_w, 
+		kernel_size, 
+		coef_x, 
+		coef_y, 
+		input.contiguous().data_ptr<float>(), 
+		output.contiguous().data_ptr<float>()
+	);
+
+	cudaFree(coef_x);
+	cudaFree(coef_y);
+
+	return output;
+}

--- a/kernels/tgs_adam.cu
+++ b/kernels/tgs_adam.cu
@@ -1,0 +1,95 @@
+#include <ATen/Dispatch.h> // AT_DISPATCH_XXX
+#include <ATen/core/Tensor.h>
+#include <c10/cuda/CUDAStream.h> // at::cuda::getCurrentCUDAStream
+#include <cooperative_groups.h>
+#include "kernels/tgs_adam.cuh"
+
+namespace taminggs {
+
+namespace cg = cooperative_groups;
+
+template <typename scalar_t>
+__global__ void adam_kernel(
+    const uint32_t N,
+    const uint32_t D,
+    scalar_t *__restrict__ param,
+    const scalar_t *__restrict__ param_grad,
+    scalar_t *__restrict__ exp_avg,
+    scalar_t *__restrict__ exp_avg_sq,
+    const bool *valid,
+    const float lr,
+    const float b1,
+    const float b2,
+    const float eps,
+    const float step_size
+) {
+    auto p_idx = cg::this_grid().thread_rank();
+    const uint32_t g_idx = p_idx / D;
+
+    if (g_idx >= N)
+        return;
+    if (valid != nullptr && !valid[g_idx])
+        return;
+
+    float register_param_grad = param_grad[p_idx];
+    float register_exp_avg = exp_avg[p_idx];
+    float register_exp_avg_sq = exp_avg_sq[p_idx];
+    register_exp_avg = b1 * register_exp_avg + (1.0f - b1) * register_param_grad; // m
+    register_exp_avg_sq = b2 * register_exp_avg_sq + (1.0f - b2) * register_param_grad * register_param_grad; //v
+    float step = - step_size * register_exp_avg / (sqrt(register_exp_avg_sq) + eps);
+
+    param[p_idx] += step;
+    exp_avg[p_idx] = register_exp_avg;
+    exp_avg_sq[p_idx] = register_exp_avg_sq;
+}
+
+void fused_adam(
+    at::Tensor &param,                    // [N, ...]
+    const at::Tensor &param_grad,         // [N, ...]
+    at::Tensor &exp_avg,                  // [N, ...]
+    at::Tensor &exp_avg_sq,               // [N, ...]
+    const at::optional<at::Tensor> valid, // [N]
+    const float lr,
+    const float b1,
+    const float b2,
+    const float eps,
+    const int64_t step
+) {
+    const uint32_t N = param.size(0);
+    const uint32_t D = param.numel() / N;
+
+    // parallel over [N, ...]
+    int64_t n_elements = N * D;
+    dim3 threads(256);
+    dim3 grid((n_elements + threads.x - 1) / threads.x);
+    int64_t shmem_size = 0; // No shared memory used in this kernel
+
+    if (n_elements == 0) {
+        // skip the kernel launch if there are no elements
+        return;
+    }
+
+    float b_corr1 = 1.0f - std::pow(b1, (float)step);
+    float b_corr2 = 1.0f - std::pow(b2, (float)step);
+    float step_size = lr * std::sqrt(b_corr2) / b_corr1;
+
+    AT_DISPATCH_FLOATING_TYPES(param.scalar_type(), "adam_kernel", [&]() {
+        adam_kernel<scalar_t>
+            <<<grid, threads, shmem_size, at::cuda::getCurrentCUDAStream()>>>(
+                N,
+                D,
+                param.data_ptr<scalar_t>(),
+                param_grad.data_ptr<scalar_t>(),
+                exp_avg.data_ptr<scalar_t>(),
+                exp_avg_sq.data_ptr<scalar_t>(),
+                valid.has_value() ? valid.value().data_ptr<bool>() : nullptr,
+                lr,
+                b1,
+                b2,
+                eps,
+                step_size
+            );
+    });
+}
+
+} // namespace taminggs

--- a/parameter/optimization_params.json
+++ b/parameter/optimization_params.json
@@ -30,5 +30,8 @@
   "bilateral_grid_lr": 0.002,
   "tv_loss_weight": 10.0,
   "steps_scaler": 1,
-  "selective_adam": false
+  "selective_adam": true,
+  "update_shN_after_every": 8,
+  "do_batch_update_after": 5000,
+  "use_visibility_mask": false
 }

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -1,6 +1,8 @@
 #include "core/camera.hpp"
 #include "core/image_io.hpp"
 
+using namespace torch::indexing;
+
 static torch::Tensor world_to_view(const torch::Tensor& R, const torch::Tensor& t) {
     assert_mat(R, 3, 3, "R");
     assert_vec(t, 3, "t");
@@ -17,6 +19,32 @@ static torch::Tensor world_to_view(const torch::Tensor& R, const torch::Tensor& 
     return Rt.t().unsqueeze(0).to(pinned_options);
 }
 
+static torch::Tensor compute_projmat(
+    const float fx, const float fy,
+    const int image_width, const int image_height, const torch::Tensor& viewmat,
+    const float near_plane = 0.01f, const float far_plane = 100.0f) {
+
+    const float cx = image_width / 2.0f;
+    const float cy = image_height / 2.0f;
+
+    float top = image_height / (2.0f * fy) * near_plane;
+    float bottom = -top;
+    float right = image_width / (2.0f * fx) * near_plane;
+    float left = -right;
+
+    const auto P = torch::zeros({4, 4}, viewmat.options());
+    P[0][0] = 2.0f * near_plane / (right - left);
+    P[1][1] = 2.0f * near_plane / (top - bottom);
+    P[2][2] = far_plane / (far_plane - near_plane);
+    P[3][2] = 1.0f;
+    P[2][3] = -far_plane * near_plane / (far_plane - near_plane);
+    P.unsqueeze(0);
+    auto projmat = torch::matmul(P, viewmat);
+
+    auto pinned_options = torch::TensorOptions().dtype(torch::kFloat32).pinned_memory(true);
+    return projmat.to(pinned_options);
+}
+
 Camera::Camera(const torch::Tensor& R,
                const torch::Tensor& T,
                float FoVx, float FoVy,
@@ -27,11 +55,17 @@ Camera::Camera(const torch::Tensor& R,
     : _uid(uid),
       _FoVx(FoVx),
       _FoVy(FoVy),
+      _tanfovx(std::tan(FoVx * 0.5f)),
+      _tanfovy(std::tan(FoVy * 0.5f)),
       _image_name(image_name),
       _image_path(image_path),
       _image_width(width),
       _image_height(height),
       _world_view_transform{world_to_view(R, T)} {
+        const float fx = _image_width / (2.f * _tanfovx);
+        const float fy = _image_height / (2.f * _tanfovy);
+        _projmat = compute_projmat(fx, fy, width, height, _world_view_transform);
+        _campos = torch::inverse(_world_view_transform).index({Slice(), Slice(0, 3), 3});
 }
 
 torch::Tensor Camera::K() const {
@@ -76,9 +110,28 @@ torch::Tensor Camera::load_and_get_image(int resolution) {
                               pinned_options)
                               .to(torch::kFloat32)
                               .permute({2, 0, 1})
-                              .clone() /
+                              .contiguous()
+                              .pin_memory() /
                           255.0f;
 
     free_image(data);
-    return image.to(torch::kCUDA, /*non_blocking=*/true);
+    return image;
+}
+
+torch::Tensor Camera::load_image_cache(int resolution) {
+
+    if (cache_on_gpu) {
+        if (!_image_cache.defined()) {
+            _image_cache = load_and_get_image(resolution).to(torch::kCUDA, /*non_blocking=*/true);
+        }
+        return _image_cache;
+    } else if (cache_on_cpu) {
+        if (!_image_cache.defined()) {
+            _image_cache = load_and_get_image(resolution);
+        }
+        return _image_cache.to(torch::kCUDA, /*non_blocking=*/true);
+    }
+
+    return load_and_get_image(resolution).to(torch::kCUDA, /*non_blocking=*/true);
+
 }

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -122,7 +122,10 @@ namespace gs {
                     {"tv_loss_weight", defaults.tv_loss_weight, "Weight for total variation loss"},
                     {"steps_scaler", defaults.steps_scaler, "Scales the training steps and values"},
                     {"sh_degree_interval", defaults.sh_degree_interval, "Interval for increasing SH degree"},
-                    {"selective_adam", defaults.selective_adam, "Selective Adam optimizer flag"}};
+                    {"selective_adam", defaults.selective_adam, "Selective Adam optimizer flag"},
+                    {"update_shN_after_every", defaults.update_shN_after_every, "Update SH degree every N steps"},
+                    {"do_batch_update_after", defaults.do_batch_update_after, "Perform batch updates after N steps"},
+                    {"use_visibility_mask", defaults.use_visibility_mask, "Use visibility mask in selective Adam"}};
 
                 // Check all expected parameters
                 for (const auto& param : expected_params) {
@@ -327,6 +330,15 @@ namespace gs {
             if (json.contains("selective_adam")) {
                 params.selective_adam = json["selective_adam"];
             }
+            if (json.contains("update_shN_after_every")) {
+                params.update_shN_after_every = json["update_shN_after_every"];
+            }
+            if (json.contains("do_batch_update_after")) {
+                params.do_batch_update_after = json["do_batch_update_after"];
+            }
+            if (json.contains("use_visibility_mask")) {
+                params.use_visibility_mask = json["use_visibility_mask"];
+            }
             return params;
         }
 
@@ -399,6 +411,9 @@ namespace gs {
             opt_json["steps_scaler"] = params.optimization.steps_scaler;
             opt_json["sh_degree_interval"] = params.optimization.sh_degree_interval;
             opt_json["selective_adam"] = params.optimization.selective_adam;
+            opt_json["update_shN_after_every"] = params.optimization.update_shN_after_every;
+            opt_json["do_batch_update_after"] = params.optimization.do_batch_update_after;
+            opt_json["use_visibility_mask"] = params.optimization.use_visibility_mask;
 
             json["optimization"] = opt_json;
 

--- a/src/rasterizer_tgs.cpp
+++ b/src/rasterizer_tgs.cpp
@@ -1,0 +1,78 @@
+#include "Ops.h"
+#include <torch/torch.h>
+
+#include "core/rasterizer.hpp" // For gs::RenderMode and gs::RenderOutput definitions
+#include "core/rasterizer_tgs.hpp"
+#include "core/rasterizer_tgs_autograd.hpp"
+
+namespace tgs {
+
+    gs::RenderOutput rasterize(
+        Camera& viewpoint_camera,
+        const SplatData& gaussian_model,
+        torch::Tensor& bg_color,
+        float scaling_modifier/*=1*/,
+        bool packed/*=false*/,
+        bool antialiased/*=false*/,
+        gs::RenderMode render_mode) {
+
+        // Ensure we don't use packed mode (not supported in this implementation)
+        TORCH_CHECK(!packed, "Packed mode is not supported in this implementation");
+
+        const int image_height = int(viewpoint_camera.image_height());
+        const int image_width = int(viewpoint_camera.image_width());
+
+        auto viewmat = viewpoint_camera.world_view_transform().to(torch::kCUDA);
+        auto projmat = viewpoint_camera.projmat().to(torch::kCUDA);
+        auto campos = viewpoint_camera.campos().to(torch::kCUDA);
+
+        const float tanfovx = viewpoint_camera.tanfovx();
+        const float tanfovy = viewpoint_camera.tanfovy();
+
+        auto means3D = gaussian_model.get_means();
+        auto opacities = gaussian_model.get_opacity();
+        if (opacities.dim() == 2 && opacities.size(1) == 1) {
+            opacities = opacities.squeeze(-1);
+        }
+        const auto scales = gaussian_model.get_scaling();
+        const auto rotations = gaussian_model.get_rotation();
+        const auto sh0 = gaussian_model.get_sh0();
+        const auto shN = gaussian_model.get_shN();
+        const int sh_degree = gaussian_model.get_active_sh_degree();
+
+        auto settings = torch::tensor({
+            scaling_modifier,
+            (float)image_height, (float)image_width,
+            (float)sh_degree,
+            (float)antialiased,
+            tanfovx, tanfovy},
+            means3D.options()
+        );
+
+        const auto result = tgs::RasterizationFunction::apply(
+            means3D,
+            sh0, shN,
+            /*colors_precomp=*/torch::empty({0}, torch::kFloat32),
+            opacities,
+            scales,
+            rotations,
+            /*cov3Ds_precomp=*/torch::empty({0}, torch::kFloat32),
+            viewmat,
+            projmat,
+            bg_color,
+            campos,
+            settings
+        );
+
+        gs::RenderOutput out;
+        out.image = result[0];
+        out.depths = torch::empty({0}, torch::kFloat32);
+        out.radii = result[1];
+        out.visibility = (out.radii > 0);
+        out.width  = image_width;
+        out.height = image_height;
+        return out;
+        
+    }
+
+}

--- a/src/rasterizer_tgs_autograd.cpp
+++ b/src/rasterizer_tgs_autograd.cpp
@@ -1,0 +1,194 @@
+#include "Ops.h"
+#include "core/camera.hpp"
+#include "core/splat_data.hpp"
+#include <torch/torch.h>
+#include "core/rasterizer_tgs_autograd.hpp"
+#include "rasterize_points.h" 
+#include <cmath>
+
+namespace tgs {
+
+    torch::autograd::variable_list RasterizationFunction::forward(
+        torch::autograd::AutogradContext* ctx,
+        const torch::Tensor& means3D,
+        const torch::Tensor& sh0,
+        const torch::Tensor& shN,
+        const torch::Tensor& colors_precomp,
+        const torch::Tensor& opacities,
+        const torch::Tensor& scales,
+        const torch::Tensor& rotations,
+        const torch::Tensor& cov3Ds_precomp,
+        const torch::Tensor& viewmat,      // [B,4,4]
+        const torch::Tensor& projmat,           // [B,3,3]
+        const torch::Tensor& bg_color,     // [B,3] or [3]
+        const torch::Tensor& campos,
+        const torch::Tensor& settings)     // [5]  {scale_mod, H, W, sh_degree, antialias}
+    {
+
+        ctx->set_materialize_grads(false);
+
+        const float scaling_modifier = settings[0].item<float>();
+        const int   image_height     = settings[1].item<int>();
+        const int   image_width      = settings[2].item<int>();
+        const int   sh_degree        = settings[3].item<int>();
+        const bool  antialiased      = settings[4].item<bool>();
+        const float tan_fovx         = settings[5].item<float>(); 
+        const float tan_fovy         = settings[6].item<float>();
+
+        auto [
+            num_rendered,
+            num_buckets,
+            color,
+            radii,
+            geomBuf,
+            binningBuf,
+            imgBuf,
+            sampleBuf,
+            offsetBuf,
+            listBuf,
+            listBufR,
+            listBufD,
+            xy_d,
+            depths_d,
+            radii_d,
+            acc_w,
+            acc_c,
+            acc_b,
+            acc_d
+        ] = taminggs::RasterizeGaussiansCUDA(
+            /*background   */ bg_color,
+            /*means        */ means3D,
+            /*colors       */ colors_precomp,
+            /*opacity      */ opacities,
+            /*scales       */ scales,
+            /*rotations    */ rotations,
+            /*scale_mod    */ scaling_modifier,
+            /*cov3D        */ cov3Ds_precomp,
+            /*viewmatrix   */ viewmat.transpose(1, 2), // glm expects column major
+            /*projmatrix   */ projmat.transpose(1, 2), // glm expects column major
+            /*tan_fovx     */ tan_fovx,
+            /*tan_fovy     */ tan_fovy,
+            /*H, W         */ image_height, image_width,
+            /*dc           */ sh0,
+            /*shs          */ shN,
+            /*degree       */ sh_degree,
+            /*campos       */ campos,
+            /*prefiltered  */ antialiased,
+            /*debug        */ false,
+            /*pixel_weights*/ torch::empty({0}, torch::kFloat32)
+        );
+
+        auto grad_settings = torch::tensor({
+            scaling_modifier,
+            (float)sh_degree,
+            (float)antialiased,
+            tan_fovx, tan_fovy,
+            (float)num_rendered, (float)num_buckets },
+            torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA)
+        );
+
+        ctx->save_for_backward({
+            means3D, scales, rotations, sh0, shN,
+            viewmat, projmat, campos, bg_color,
+            colors_precomp, cov3Ds_precomp, radii,
+            geomBuf, imgBuf, binningBuf, sampleBuf,
+            grad_settings
+        });
+
+        // image, depth, radii
+        return {color, radii, geomBuf, binningBuf, imgBuf, sampleBuf,
+                offsetBuf, listBuf, listBufR, listBufD, xy_d, depths_d,
+                radii_d, acc_w, acc_c, acc_b, acc_d};
+
+        }
+
+    torch::autograd::variable_list RasterizationFunction::backward(
+        torch::autograd::AutogradContext* ctx,
+        torch::autograd::variable_list grad_outputs)
+    {
+
+        torch::Tensor grad_out_color = grad_outputs[0];
+
+        // 1) Grab the vector of saved tensors
+        auto saved = ctx->get_saved_variables();
+
+        // 2) Unpack in the same order you saved them
+        auto means3D        = saved[0];
+        auto scales         = saved[1];
+        auto rotations      = saved[2];
+        auto sh0             = saved[3];
+        auto shN            = saved[4];
+        auto viewmat        = saved[5];
+        auto projmat        = saved[6];
+        auto campos         = saved[7];
+        auto bg_color       = saved[8];
+        auto colors_precomp = saved[9];
+        auto cov3Ds_precomp = saved[10];
+        auto radii          = saved[11];
+        auto geomBuf        = saved[12];
+        auto imgBuf         = saved[13];
+        auto binningBuf     = saved[14];
+        auto sampleBuf      = saved[15];
+
+        // finally, your grad_settings tensor is at index 12
+        auto grad_settings  = saved[16];
+
+        // 3) Pull individual floats/ints/bools back out of grad_settings
+        float scaling_modifier = grad_settings[0].item<float>();
+        int   sh_degree        = static_cast<int>(grad_settings[1].item<float>());
+        bool  antialiased      = static_cast<bool>(grad_settings[2].item<float>());
+        float tan_fovx         = grad_settings[3].item<float>();
+        float tan_fovy         = grad_settings[4].item<float>();
+        int   num_rendered     = static_cast<int>(grad_settings[5].item<float>());
+        int   num_buckets      = static_cast<int>(grad_settings[6].item<float>());
+
+        // 4) Now call your CUDA backward kernel, re‑using all of those
+        auto [
+            grad_means2D, grad_colors_precomp, grad_opacities, grad_means3D,
+            grad_cov3Ds_precomp, grad_sh0, grad_shN, grad_scales, grad_rotations
+        ] = taminggs::RasterizeGaussiansBackwardCUDA(
+            /*bg*/        bg_color,
+            /*means3D*/   means3D,
+            /*radii*/     radii,
+            /*colors*/    colors_precomp,
+            /*scales*/    scales,
+            /*rots*/      rotations,
+            /*scale_mod*/ scaling_modifier,
+            /*cov3D*/     cov3Ds_precomp,
+            /*viewmat*/   viewmat.transpose(1,2),
+            /*projmat*/   projmat.transpose(1,2),
+            /*tan x*/     tan_fovx,
+            /*tan y*/     tan_fovy,
+            /*dL/dout*/   grad_out_color,
+            /*dc*/        sh0,
+            /*sh*/        shN,
+            /*degree*/    sh_degree,
+            /*campos*/    campos,
+            /*geomBuf*/   geomBuf,
+            /*R*/         num_rendered,
+            /*binBuf*/    binningBuf,
+            /*imgBuf*/    imgBuf,
+            /*B*/         num_buckets,
+            /*sampBuf*/   sampleBuf,
+            /*debug*/     false
+        );
+
+        return {
+            grad_means3D,
+            grad_sh0,
+            grad_shN,
+            grad_colors_precomp,
+            grad_opacities.squeeze(1),
+            grad_scales,
+            grad_rotations,
+            grad_cov3Ds_precomp,
+            torch::Tensor(),
+            torch::Tensor(),
+            torch::Tensor(),
+            torch::Tensor(),
+            torch::Tensor()
+        };
+
+    }
+
+}

--- a/src/selective_adam.cpp
+++ b/src/selective_adam.cpp
@@ -1,6 +1,8 @@
 #include "core/selective_adam.hpp"
 #include "Ops.h"
 #include <torch/torch.h>
+#include "kernels/tgs_adam.cuh"
+#include <ATen/ATen.h>
 
 namespace gs {
 
@@ -9,22 +11,118 @@ namespace gs {
         return {};
     }
 
-    void SelectiveAdam::step(const torch::Tensor& visibility_mask) {
+    // void SelectiveAdam::step(const int iter, const torch::Tensor& visibility_mask) {
+    //     torch::NoGradGuard no_grad;
+
+    //     TORCH_CHECK(visibility_mask.dim() == 1, "visibility_mask must be 1D tensor");
+    //     TORCH_CHECK(visibility_mask.dtype() == torch::kBool, "visibility_mask must be boolean tensor");
+
+    //     const int64_t N = visibility_mask.numel();
+
+    //     // Get global options
+    //     const auto& global_options = options();
+
+    //     // int group_id = 0;
+    //     for (auto& group : param_groups()) {
+
+    //         // group_id++;
+    //         // for shN group only update every 16th iteration
+    //         // want to do this a batched update
+    //         // how do I take the average of group shN grad and update only after 16 steps
+    //         // if (group_id == 3 && iter % 16 != 0) continue;
+
+    //         // For each group, check if it has specific options
+    //         double lr = global_options.lr();
+    //         double eps = global_options.eps();
+    //         auto [beta1, beta2] = global_options.betas();
+    //         double weight_decay = global_options.weight_decay();
+    //         bool amsgrad = global_options.amsgrad();
+
+    //         // If the group has its own options, use those
+    //         if (group.has_options()) {
+    //             if (auto* group_opts = dynamic_cast<const Options*>(&group.options())) {
+    //                 lr = group_opts->lr();
+    //                 eps = group_opts->eps();
+    //                 std::tie(beta1, beta2) = group_opts->betas();
+    //             }
+    //         }
+
+    //         for (auto& param : group.params()) {
+
+    //             if (!param.grad().defined()) {
+    //                 continue;
+    //             }
+
+    //             // Check that this parameter's first dimension matches visibility mask
+    //             TORCH_CHECK(param.size(0) == N,
+    //                         "Parameter first dimension (", param.size(0),
+    //                         ") must match visibility mask size (", N, ")");
+
+    //             // Lazy state initialization
+    //             auto state_ptr = state_.find(param.unsafeGetTensorImpl());
+    //             if (state_ptr == state_.end()) {
+    //                 auto new_state = std::make_unique<AdamParamState>();
+    //                 new_state->step_count = 0;
+    //                 new_state->exp_avg = torch::zeros_like(param, torch::MemoryFormat::Preserve);
+    //                 new_state->exp_avg_sq = torch::zeros_like(param, torch::MemoryFormat::Preserve);
+
+    //                 state_[param.unsafeGetTensorImpl()] = std::move(new_state);
+    //                 state_ptr = state_.find(param.unsafeGetTensorImpl());
+    //             }
+
+    //             auto& state = static_cast<AdamParamState&>(*state_ptr->second);
+
+    //             // Increment step
+    //             state.step_count++;
+
+    //             // Call the fused CUDA kernel from taminggs
+    //             taminggs::fused_adam(
+    //                 param,
+    //                 param.grad(),
+    //                 state.exp_avg,
+    //                 state.exp_avg_sq,
+    //                 /*visibility_mask*/c10::nullopt,
+    //                 static_cast<float>(lr),
+    //                 static_cast<float>(beta1),
+    //                 static_cast<float>(beta2),
+    //                 static_cast<float>(eps),
+    //                 static_cast<int64_t>(iter)
+    //             );
+
+    //             // gsplat::adam(
+    //             //     param,
+    //             //     param.grad(),
+    //             //     state.exp_avg,
+    //             //     state.exp_avg_sq,
+    //             //     visibility_mask, // Pass as optional
+    //             //     static_cast<float>(lr),
+    //             //     static_cast<float>(beta1),
+    //             //     static_cast<float>(beta2),
+    //             //     static_cast<float>(eps));
+    //         }
+    //     }
+    // }
+
+    void SelectiveAdam::step(const int iter, const torch::Tensor& visibility_mask) {
         torch::NoGradGuard no_grad;
 
-        TORCH_CHECK(visibility_mask.dim() == 1, "visibility_mask must be 1D tensor");
-        TORCH_CHECK(visibility_mask.dtype() == torch::kBool, "visibility_mask must be boolean tensor");
-
+        TORCH_CHECK(visibility_mask.dim() == 1, "visibility_mask must be 1D");
+        TORCH_CHECK(visibility_mask.dtype() == torch::kBool, "visibility_mask must be bool");
         const int64_t N = visibility_mask.numel();
 
         // Get global options
         const auto& global_options = options();
 
+        int group_id = 0;
         for (auto& group : param_groups()) {
+            group_id++;
+
             // For each group, check if it has specific options
             double lr = global_options.lr();
             double eps = global_options.eps();
             auto [beta1, beta2] = global_options.betas();
+            double weight_decay = global_options.weight_decay();
+            bool amsgrad = global_options.amsgrad();
 
             // If the group has its own options, use those
             if (group.has_options()) {
@@ -35,7 +133,11 @@ namespace gs {
                 }
             }
 
+            const int  acc_steps = (group_id == 3) && iter >= do_batch_update_after_ ? update_shN_after_every_ : 1;
+            const bool do_update_now = (acc_steps == 1) ? true : ((iter + 1) % acc_steps == 0);
+
             for (auto& param : group.params()) {
+
                 if (!param.grad().defined()) {
                     continue;
                 }
@@ -52,27 +154,64 @@ namespace gs {
                     new_state->step_count = 0;
                     new_state->exp_avg = torch::zeros_like(param, torch::MemoryFormat::Preserve);
                     new_state->exp_avg_sq = torch::zeros_like(param, torch::MemoryFormat::Preserve);
-
                     state_[param.unsafeGetTensorImpl()] = std::move(new_state);
                     state_ptr = state_.find(param.unsafeGetTensorImpl());
                 }
 
                 auto& state = static_cast<AdamParamState&>(*state_ptr->second);
 
-                // Increment step
-                state.step_count++;
+                if (acc_steps > 1) {
 
-                // Call the fused CUDA kernel from gsplat
-                gsplat::adam(
-                    param,
-                    param.grad(),
-                    state.exp_avg,
-                    state.exp_avg_sq,
-                    visibility_mask, // Pass as optional
-                    static_cast<float>(lr),
-                    static_cast<float>(beta1),
-                    static_cast<float>(beta2),
-                    static_cast<float>(eps));
+                    if (!state.grad_accum.defined()) {
+                        state.grad_accum = torch::zeros_like(param.grad(), torch::MemoryFormat::Preserve);
+                        state.micro_count = 0;
+                    }
+
+                    state.grad_accum.add_(param.grad());
+                    state.micro_count++;
+
+                    if (!do_update_now) continue;
+
+                    const float inv = 1.0f / static_cast<float>(state.micro_count);
+                    torch::Tensor avg_grad = state.grad_accum.mul(inv);
+
+                    // Increment step_count only on macro-step (bias-correction correctness)
+                    state.step_count++;
+
+                    taminggs::fused_adam(
+                        param,
+                        avg_grad,
+                        state.exp_avg,
+                        state.exp_avg_sq,
+                        use_visibility_mask_ ? c10::optional<at::Tensor>(visibility_mask) : c10::nullopt,
+                        static_cast<float>(lr),
+                        static_cast<float>(beta1),
+                        static_cast<float>(beta2),
+                        static_cast<float>(eps),
+                        static_cast<int64_t>(state.step_count)
+                    );
+
+                    state.grad_accum.zero_();
+                    state.micro_count = 0;
+
+                } else {
+
+                    state.step_count++;
+
+                    taminggs::fused_adam(
+                        param,
+                        param.grad(),
+                        state.exp_avg,
+                        state.exp_avg_sq,
+                        use_visibility_mask_ ? c10::optional<at::Tensor>(visibility_mask) : c10::nullopt,
+                        static_cast<float>(lr),
+                        static_cast<float>(beta1),
+                        static_cast<float>(beta2),
+                        static_cast<float>(eps),
+                        static_cast<int64_t>(state.step_count)
+                    );
+
+                }
             }
         }
     }

--- a/src/splat_data.cpp
+++ b/src/splat_data.cpp
@@ -244,6 +244,14 @@ torch::Tensor SplatData::get_shs() const {
     return torch::cat({_sh0, _shN}, 1);
 }
 
+torch::Tensor SplatData::get_sh0() const {
+    return _sh0;
+}
+
+torch::Tensor SplatData::get_shN() const {
+    return _shN;
+}
+
 // Utility method
 void SplatData::increment_sh_degree() {
     if (_active_sh_degree < _max_sh_degree) {

--- a/taminggs/CMakeLists.txt
+++ b/taminggs/CMakeLists.txt
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 3.24...3.30)
+
+# Get torch from parent
+if(NOT DEFINED TORCH_INCLUDE_DIRS)
+    find_package(Torch REQUIRED)
+endif()
+
+# All gsplat sources together
+set(TAMINGGS_SOURCES
+        # C++ files
+
+        # CUDA files
+        adam.cu
+        backward.cu
+        forward.cu
+        rasterize_points.cu
+        rasterizer_impl.cu
+)
+
+# One unified library
+add_library(taminggs_backend STATIC ${TAMINGGS_SOURCES})
+
+set_target_properties(taminggs_backend PROPERTIES
+        CUDA_ARCHITECTURES native
+        CUDA_SEPARABLE_COMPILATION ON
+        POSITION_INDEPENDENT_CODE ON
+        CUDA_RESOLVE_DEVICE_SYMBOLS ON
+)
+
+target_include_directories(taminggs_backend
+        PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_SOURCE_DIR}/include
+        ${TORCH_INCLUDE_DIRS}
+        PRIVATE
+        ${Python3_INCLUDE_DIRS}
+)
+
+target_link_libraries(taminggs_backend
+        PUBLIC
+        ${TORCH_LIBRARIES}
+        CUDA::cudart
+        CUDA::curand
+        CUDA::cublas
+        glm::glm
+)
+
+# Compile options for both CUDA and C++
+target_compile_options(taminggs_backend PRIVATE
+        $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CUDA>>:-O0 -g -G -lineinfo>
+        $<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:CUDA>>:-O3 --use_fast_math --expt-relaxed-constexpr -diag-suppress=20012,186>
+        $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CXX>>:-O0 -g>
+        $<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:CXX>>:-O3>
+)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_definitions(taminggs_backend PRIVATE _DEBUG DEBUG_BUILD)
+elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
+    target_compile_definitions(taminggs_backend PRIVATE RELEASE_BUILD)
+endif()

--- a/taminggs/adam.cu
+++ b/taminggs/adam.cu
@@ -1,0 +1,67 @@
+#include "auxiliary.h"
+#include "adam.h"
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+namespace cg = cooperative_groups;
+
+// step on a grid of size (N, M)
+// N is always number of gaussians
+__global__
+void adamUpdateCUDA(
+    float* __restrict__ param,
+    const float* __restrict__ param_grad,
+    float* __restrict__ exp_avg,
+    float* __restrict__ exp_avg_sq,
+    const bool* tiles_touched,
+    const float lr,
+    const float b1,
+    const float b2,
+    const float eps,
+    const uint32_t N,
+    const uint32_t M) {
+
+	auto p_idx = cg::this_grid().thread_rank();
+    const uint32_t g_idx = p_idx / M;
+    if (g_idx >= N) return;
+    if (tiles_touched[g_idx]) {
+        float Register_param_grad = param_grad[p_idx];
+        float Register_exp_avg = exp_avg[p_idx];
+        float Register_exp_avg_sq = exp_avg_sq[p_idx];
+        Register_exp_avg = b1 * Register_exp_avg + (1.0f - b1) * Register_param_grad;
+        Register_exp_avg_sq = b2 * Register_exp_avg_sq + (1.0f - b2) * Register_param_grad * Register_param_grad;
+        float step = -lr * Register_exp_avg / (sqrt(Register_exp_avg_sq) + eps);
+
+        param[p_idx] += step;
+        exp_avg[p_idx] = Register_exp_avg;
+        exp_avg_sq[p_idx] = Register_exp_avg_sq;
+    }
+}
+
+void ADAM::adamUpdate(
+    float* param,
+    const float* param_grad,
+    float* exp_avg,
+    float* exp_avg_sq,
+    const bool* tiles_touched,
+    const float lr,
+    const float b1,
+    const float b2,
+    const float eps,
+    const uint32_t N,
+    const uint32_t M) {
+
+    const uint32_t cnt = N * M;
+    adamUpdateCUDA<<<(cnt + 255) / 256, 256>>> (
+        param,
+        param_grad,
+        exp_avg,
+        exp_avg_sq,
+        tiles_touched,
+        lr,
+        b1,
+        b2,
+        eps,
+        N,
+        M
+    );
+}

--- a/taminggs/adam.h
+++ b/taminggs/adam.h
@@ -1,0 +1,26 @@
+#ifndef CUDA_RASTERIZER_ADAM_H_INCLUDED
+#define CUDA_RASTERIZER_ADAM_H_INCLUDED
+
+#include <cuda.h>
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+#define GLM_FORCE_CUDA
+#include <glm/glm.hpp>
+
+namespace ADAM {
+
+void adamUpdate(
+    float* param,
+    const float* param_grad,
+    float* exp_avg,
+    float* exp_avg_sq,
+    const bool* tiles_touched,
+    const float lr,
+    const float b1,
+    const float b2,
+    const float eps,
+    const uint32_t N,
+    const uint32_t M);
+}
+
+#endif

--- a/taminggs/auxiliary.h
+++ b/taminggs/auxiliary.h
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#ifndef CUDA_RASTERIZER_AUXILIARY_H_INCLUDED
+#define CUDA_RASTERIZER_AUXILIARY_H_INCLUDED
+
+#include "config.h"
+#include "stdio.h"
+
+#define BLOCK_SIZE (BLOCK_X * BLOCK_Y)
+#define NUM_WARPS (BLOCK_SIZE/32)
+
+// Spherical harmonics coefficients
+__device__ const float SH_C0 = 0.28209479177387814f;
+__device__ const float SH_C1 = 0.4886025119029199f;
+__device__ const float SH_C2[] = {
+	1.0925484305920792f,
+	-1.0925484305920792f,
+	0.31539156525252005f,
+	-1.0925484305920792f,
+	0.5462742152960396f
+};
+__device__ const float SH_C3[] = {
+	-0.5900435899266435f,
+	2.890611442640554f,
+	-0.4570457994644658f,
+	0.3731763325901154f,
+	-0.4570457994644658f,
+	1.445305721320277f,
+	-0.5900435899266435f
+};
+
+__forceinline__ __device__ float ndc2Pix(float v, int S)
+{
+	return ((v + 1.0) * S - 1.0) * 0.5;
+}
+
+__forceinline__ __device__ void getRect(const float2 p, int max_radius, uint2& rect_min, uint2& rect_max, dim3 grid)
+{
+	rect_min = {
+		min(grid.x, max((int)0, (int)((p.x - max_radius) / BLOCK_X))),
+		min(grid.y, max((int)0, (int)((p.y - max_radius) / BLOCK_Y)))
+	};
+	rect_max = {
+		min(grid.x, max((int)0, (int)((p.x + max_radius + BLOCK_X - 1) / BLOCK_X))),
+		min(grid.y, max((int)0, (int)((p.y + max_radius + BLOCK_Y - 1) / BLOCK_Y)))
+	};
+}
+
+__forceinline__ __device__ void getRect(const float2 p, int2 ext_rect, uint2& rect_min, uint2& rect_max, dim3 grid)
+{
+	rect_min = {
+		min(grid.x, max((int)0, (int)((p.x - ext_rect.x) / BLOCK_X))),
+		min(grid.y, max((int)0, (int)((p.y - ext_rect.y) / BLOCK_Y)))
+	};
+	rect_max = {
+		min(grid.x, max((int)0, (int)((p.x + ext_rect.x + BLOCK_X - 1) / BLOCK_X))),
+		min(grid.y, max((int)0, (int)((p.y + ext_rect.y + BLOCK_Y - 1) / BLOCK_Y)))
+	};
+}
+
+__forceinline__ __device__ float3 transformPoint4x3(const float3& p, const float* matrix)
+{
+	float3 transformed = {
+		matrix[0] * p.x + matrix[4] * p.y + matrix[8] * p.z + matrix[12],
+		matrix[1] * p.x + matrix[5] * p.y + matrix[9] * p.z + matrix[13],
+		matrix[2] * p.x + matrix[6] * p.y + matrix[10] * p.z + matrix[14],
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float4 transformPoint4x4(const float3& p, const float* matrix)
+{
+	float4 transformed = {
+		matrix[0] * p.x + matrix[4] * p.y + matrix[8] * p.z + matrix[12],
+		matrix[1] * p.x + matrix[5] * p.y + matrix[9] * p.z + matrix[13],
+		matrix[2] * p.x + matrix[6] * p.y + matrix[10] * p.z + matrix[14],
+		matrix[3] * p.x + matrix[7] * p.y + matrix[11] * p.z + matrix[15]
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float3 transformVec4x3(const float3& p, const float* matrix)
+{
+	float3 transformed = {
+		matrix[0] * p.x + matrix[4] * p.y + matrix[8] * p.z,
+		matrix[1] * p.x + matrix[5] * p.y + matrix[9] * p.z,
+		matrix[2] * p.x + matrix[6] * p.y + matrix[10] * p.z,
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float3 transformVec4x3Transpose(const float3& p, const float* matrix)
+{
+	float3 transformed = {
+		matrix[0] * p.x + matrix[1] * p.y + matrix[2] * p.z,
+		matrix[4] * p.x + matrix[5] * p.y + matrix[6] * p.z,
+		matrix[8] * p.x + matrix[9] * p.y + matrix[10] * p.z,
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float dnormvdz(float3 v, float3 dv)
+{
+	float sum2 = v.x * v.x + v.y * v.y + v.z * v.z;
+	float invsum32 = 1.0f / sqrt(sum2 * sum2 * sum2);
+	float dnormvdz = (-v.x * v.z * dv.x - v.y * v.z * dv.y + (sum2 - v.z * v.z) * dv.z) * invsum32;
+	return dnormvdz;
+}
+
+__forceinline__ __device__ float3 dnormvdv(float3 v, float3 dv)
+{
+	float sum2 = v.x * v.x + v.y * v.y + v.z * v.z;
+	float invsum32 = 1.0f / sqrt(sum2 * sum2 * sum2);
+
+	float3 dnormvdv;
+	dnormvdv.x = ((+sum2 - v.x * v.x) * dv.x - v.y * v.x * dv.y - v.z * v.x * dv.z) * invsum32;
+	dnormvdv.y = (-v.x * v.y * dv.x + (sum2 - v.y * v.y) * dv.y - v.z * v.y * dv.z) * invsum32;
+	dnormvdv.z = (-v.x * v.z * dv.x - v.y * v.z * dv.y + (sum2 - v.z * v.z) * dv.z) * invsum32;
+	return dnormvdv;
+}
+
+__forceinline__ __device__ float4 dnormvdv(float4 v, float4 dv)
+{
+	float sum2 = v.x * v.x + v.y * v.y + v.z * v.z + v.w * v.w;
+	float invsum32 = 1.0f / sqrt(sum2 * sum2 * sum2);
+
+	float4 vdv = { v.x * dv.x, v.y * dv.y, v.z * dv.z, v.w * dv.w };
+	float vdv_sum = vdv.x + vdv.y + vdv.z + vdv.w;
+	float4 dnormvdv;
+	dnormvdv.x = ((sum2 - v.x * v.x) * dv.x - v.x * (vdv_sum - vdv.x)) * invsum32;
+	dnormvdv.y = ((sum2 - v.y * v.y) * dv.y - v.y * (vdv_sum - vdv.y)) * invsum32;
+	dnormvdv.z = ((sum2 - v.z * v.z) * dv.z - v.z * (vdv_sum - vdv.z)) * invsum32;
+	dnormvdv.w = ((sum2 - v.w * v.w) * dv.w - v.w * (vdv_sum - vdv.w)) * invsum32;
+	return dnormvdv;
+}
+
+__forceinline__ __device__ float sigmoid(float x)
+{
+	return 1.0f / (1.0f + expf(-x));
+}
+
+__forceinline__ __device__ bool in_frustum(int idx,
+	const float* orig_points,
+	const float* viewmatrix,
+	const float* projmatrix,
+	bool prefiltered,
+	float3& p_view)
+{
+	float3 p_orig = { orig_points[3 * idx], orig_points[3 * idx + 1], orig_points[3 * idx + 2] };
+
+	// Bring points to screen space
+	float4 p_hom = transformPoint4x4(p_orig, projmatrix);
+	float p_w = 1.0f / (p_hom.w + 0.0000001f);
+	float3 p_proj = { p_hom.x * p_w, p_hom.y * p_w, p_hom.z * p_w };
+	p_view = transformPoint4x3(p_orig, viewmatrix);
+
+	if (p_view.z <= 0.2f)// || ((p_proj.x < -1.3 || p_proj.x > 1.3 || p_proj.y < -1.3 || p_proj.y > 1.3)))
+	{
+		if (prefiltered)
+		{
+			printf("Point is filtered although prefiltered is set. This shouldn't happen!");
+			__trap();
+		}
+		return false;
+	}
+	return true;
+}
+
+// #define CHECK_CUDA(A, debug) \
+// A; if(debug) { \
+// auto ret = cudaDeviceSynchronize(); \
+// if (ret != cudaSuccess) { \
+// std::cerr << "\n[CUDA ERROR] in " << __FILE__ << "\nLine " << __LINE__ << ": " << cudaGetErrorString(ret); \
+// throw std::runtime_error(cudaGetErrorString(ret)); \
+// } \
+// }
+
+//  ─────────────────────────────────────────────────────────────────────────────
+//  CHECK_CUDA ‒ run `A`, then (when debug == true)   ‒
+//               1. do a device-sync,                ‒
+//               2. throw if any asynchronous error  ‒
+//                  occurred during A.               ‒
+//  The error message now prints file, line *and* the ‒
+//  host function in which the macro was expanded.   ‒
+//  ─────────────────────────────────────────────────────────────────────────────
+#define CHECK_CUDA(A, debug)                                                     \
+    do {                                                                         \
+        A;                                                                       \
+        if (debug) {                                                             \
+            cudaError_t _err = cudaDeviceSynchronize();                          \
+            if (_err != cudaSuccess) {                                           \
+                std::cerr << "\n[CUDA ERROR] in " << __FILE__ << ':' << __LINE__ \
+                          << " (" << __func__ << "): "                           \
+                          << cudaGetErrorString(_err) << std::endl;              \
+                throw std::runtime_error(cudaGetErrorString(_err));              \
+            }                                                                    \
+        }                                                                        \
+    } while (0)
+
+
+#endif

--- a/taminggs/backward.cu
+++ b/taminggs/backward.cu
@@ -1,0 +1,889 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#include "backward.h"
+#include "auxiliary.h"
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+namespace cg = cooperative_groups;
+
+// Backward pass for conversion of spherical harmonics to RGB for
+// each Gaussian.
+__device__ void computeColorFromSH(int idx, int deg, int max_coeffs, const glm::vec3* means, glm::vec3 campos, const float* dc, const float* shs, const bool* clamped, const glm::vec3* dL_dcolor, glm::vec3* dL_dmeans, glm::vec3* dL_ddc, glm::vec3* dL_dshs)
+{
+	// Compute intermediate values, as it is done during forward
+	glm::vec3 pos = means[idx];
+	glm::vec3 dir_orig = pos - campos;
+	glm::vec3 dir = dir_orig / glm::length(dir_orig);
+
+	glm::vec3* direct_color = ((glm::vec3*)dc) + idx;
+	glm::vec3* sh = ((glm::vec3*)shs) + idx * max_coeffs;
+
+	// Use PyTorch rule for clamping: if clamping was applied,
+	// gradient becomes 0.
+	glm::vec3 dL_dRGB = dL_dcolor[idx];
+	dL_dRGB.x *= clamped[3 * idx + 0] ? 0 : 1;
+	dL_dRGB.y *= clamped[3 * idx + 1] ? 0 : 1;
+	dL_dRGB.z *= clamped[3 * idx + 2] ? 0 : 1;
+
+	glm::vec3 dRGBdx(0, 0, 0);
+	glm::vec3 dRGBdy(0, 0, 0);
+	glm::vec3 dRGBdz(0, 0, 0);
+	float x = dir.x;
+	float y = dir.y;
+	float z = dir.z;
+
+	// Target location for this Gaussian to write SH gradients to
+	glm::vec3* dL_ddirect_color = dL_ddc + idx;
+	glm::vec3* dL_dsh = dL_dshs + idx * max_coeffs;
+
+	// No tricks here, just high school-level calculus.
+	float dRGBdsh0 = SH_C0;
+	dL_ddirect_color[0] = dRGBdsh0 * dL_dRGB;
+	if (deg > 0)
+	{
+		float dRGBdsh1 = -SH_C1 * y;
+		float dRGBdsh2 = SH_C1 * z;
+		float dRGBdsh3 = -SH_C1 * x;
+		dL_dsh[0] = dRGBdsh1 * dL_dRGB;
+		dL_dsh[1] = dRGBdsh2 * dL_dRGB;
+		dL_dsh[2] = dRGBdsh3 * dL_dRGB;
+
+		dRGBdx = -SH_C1 * sh[2];
+		dRGBdy = -SH_C1 * sh[0];
+		dRGBdz = SH_C1 * sh[1];
+
+		if (deg > 1)
+		{
+			float xx = x * x, yy = y * y, zz = z * z;
+			float xy = x * y, yz = y * z, xz = x * z;
+
+			float dRGBdsh4 = SH_C2[0] * xy;
+			float dRGBdsh5 = SH_C2[1] * yz;
+			float dRGBdsh6 = SH_C2[2] * (2.f * zz - xx - yy);
+			float dRGBdsh7 = SH_C2[3] * xz;
+			float dRGBdsh8 = SH_C2[4] * (xx - yy);
+			dL_dsh[3] = dRGBdsh4 * dL_dRGB;
+			dL_dsh[4] = dRGBdsh5 * dL_dRGB;
+			dL_dsh[5] = dRGBdsh6 * dL_dRGB;
+			dL_dsh[6] = dRGBdsh7 * dL_dRGB;
+			dL_dsh[7] = dRGBdsh8 * dL_dRGB;
+
+			dRGBdx += SH_C2[0] * y * sh[3] + SH_C2[2] * 2.f * -x * sh[5] + SH_C2[3] * z * sh[6] + SH_C2[4] * 2.f * x * sh[7];
+			dRGBdy += SH_C2[0] * x * sh[3] + SH_C2[1] * z * sh[4] + SH_C2[2] * 2.f * -y * sh[5] + SH_C2[4] * 2.f * -y * sh[7];
+			dRGBdz += SH_C2[1] * y * sh[4] + SH_C2[2] * 2.f * 2.f * z * sh[5] + SH_C2[3] * x * sh[6];
+
+			if (deg > 2)
+			{
+				float dRGBdsh9 = SH_C3[0] * y * (3.f * xx - yy);
+				float dRGBdsh10 = SH_C3[1] * xy * z;
+				float dRGBdsh11 = SH_C3[2] * y * (4.f * zz - xx - yy);
+				float dRGBdsh12 = SH_C3[3] * z * (2.f * zz - 3.f * xx - 3.f * yy);
+				float dRGBdsh13 = SH_C3[4] * x * (4.f * zz - xx - yy);
+				float dRGBdsh14 = SH_C3[5] * z * (xx - yy);
+				float dRGBdsh15 = SH_C3[6] * x * (xx - 3.f * yy);
+				dL_dsh[8] = dRGBdsh9 * dL_dRGB;
+				dL_dsh[9] = dRGBdsh10 * dL_dRGB;
+				dL_dsh[10] = dRGBdsh11 * dL_dRGB;
+				dL_dsh[11] = dRGBdsh12 * dL_dRGB;
+				dL_dsh[12] = dRGBdsh13 * dL_dRGB;
+				dL_dsh[13] = dRGBdsh14 * dL_dRGB;
+				dL_dsh[14] = dRGBdsh15 * dL_dRGB;
+
+				dRGBdx += (
+					SH_C3[0] * sh[8] * 3.f * 2.f * xy +
+					SH_C3[1] * sh[9] * yz +
+					SH_C3[2] * sh[10] * -2.f * xy +
+					SH_C3[3] * sh[11] * -3.f * 2.f * xz +
+					SH_C3[4] * sh[12] * (-3.f * xx + 4.f * zz - yy) +
+					SH_C3[5] * sh[13] * 2.f * xz +
+					SH_C3[6] * sh[14] * 3.f * (xx - yy));
+
+				dRGBdy += (
+					SH_C3[0] * sh[8] * 3.f * (xx - yy) +
+					SH_C3[1] * sh[9] * xz +
+					SH_C3[2] * sh[10] * (-3.f * yy + 4.f * zz - xx) +
+					SH_C3[3] * sh[11] * -3.f * 2.f * yz +
+					SH_C3[4] * sh[12] * -2.f * xy +
+					SH_C3[5] * sh[13] * -2.f * yz +
+					SH_C3[6] * sh[14] * -3.f * 2.f * xy);
+
+				dRGBdz += (
+					SH_C3[1] * sh[9] * xy +
+					SH_C3[2] * sh[10] * 4.f * 2.f * yz +
+					SH_C3[3] * sh[11] * 3.f * (2.f * zz - xx - yy) +
+					SH_C3[4] * sh[12] * 4.f * 2.f * xz +
+					SH_C3[5] * sh[13] * (xx - yy));
+			}
+		}
+	}
+
+	// The view direction is an input to the computation. View direction
+	// is influenced by the Gaussian's mean, so SHs gradients
+	// must propagate back into 3D position.
+	glm::vec3 dL_ddir(glm::dot(dRGBdx, dL_dRGB), glm::dot(dRGBdy, dL_dRGB), glm::dot(dRGBdz, dL_dRGB));
+
+	// Account for normalization of direction
+	float3 dL_dmean = dnormvdv(float3{ dir_orig.x, dir_orig.y, dir_orig.z }, float3{ dL_ddir.x, dL_ddir.y, dL_ddir.z });
+
+	// Gradients of loss w.r.t. Gaussian means, but only the portion 
+	// that is caused because the mean affects the view-dependent color.
+	// Additional mean gradient is accumulated in below methods.
+	dL_dmeans[idx] += glm::vec3(dL_dmean.x, dL_dmean.y, dL_dmean.z);
+}
+
+// Backward version of INVERSE 2D covariance matrix computation
+// (due to length launched as separate kernel before other 
+// backward steps contained in preprocess)
+__global__ void computeCov2DCUDA(int P,
+	const float3* means,
+	const int* radii,
+	const float* cov3Ds,
+	const float h_x, float h_y,
+	const float tan_fovx, float tan_fovy,
+	const float* view_matrix,
+	const float* dL_dconics,
+	float3* dL_dmeans,
+	float* dL_dcov)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= P || !(radii[idx] > 0))
+		return;
+
+	// Reading location of 3D covariance for this Gaussian
+	const float* cov3D = cov3Ds + 6 * idx;
+
+	// Fetch gradients, recompute 2D covariance and relevant 
+	// intermediate forward results needed in the backward.
+	float3 mean = means[idx];
+	float3 dL_dconic = { dL_dconics[4 * idx], dL_dconics[4 * idx + 1], dL_dconics[4 * idx + 3] };
+	float3 t = transformPoint4x3(mean, view_matrix);
+	
+	const float limx = 1.3f * tan_fovx;
+	const float limy = 1.3f * tan_fovy;
+	const float txtz = t.x / t.z;
+	const float tytz = t.y / t.z;
+	t.x = min(limx, max(-limx, txtz)) * t.z;
+	t.y = min(limy, max(-limy, tytz)) * t.z;
+	
+	const float x_grad_mul = txtz < -limx || txtz > limx ? 0 : 1;
+	const float y_grad_mul = tytz < -limy || tytz > limy ? 0 : 1;
+
+	glm::mat3 J = glm::mat3(h_x / t.z, 0.0f, -(h_x * t.x) / (t.z * t.z),
+		0.0f, h_y / t.z, -(h_y * t.y) / (t.z * t.z),
+		0, 0, 0);
+
+	glm::mat3 W = glm::mat3(
+		view_matrix[0], view_matrix[4], view_matrix[8],
+		view_matrix[1], view_matrix[5], view_matrix[9],
+		view_matrix[2], view_matrix[6], view_matrix[10]);
+
+	glm::mat3 Vrk = glm::mat3(
+		cov3D[0], cov3D[1], cov3D[2],
+		cov3D[1], cov3D[3], cov3D[4],
+		cov3D[2], cov3D[4], cov3D[5]);
+
+	glm::mat3 T = W * J;
+
+	glm::mat3 cov2D = glm::transpose(T) * glm::transpose(Vrk) * T;
+
+	// Use helper variables for 2D covariance entries. More compact.
+	float a = cov2D[0][0] += 0.3f;
+	float b = cov2D[0][1];
+	float c = cov2D[1][1] += 0.3f;
+
+	float denom = a * c - b * b;
+	float dL_da = 0, dL_db = 0, dL_dc = 0;
+	float denom2inv = 1.0f / ((denom * denom) + 0.0000001f);
+
+	if (denom2inv != 0)
+	{
+		// Gradients of loss w.r.t. entries of 2D covariance matrix,
+		// given gradients of loss w.r.t. conic matrix (inverse covariance matrix).
+		// e.g., dL / da = dL / d_conic_a * d_conic_a / d_a
+		dL_da = denom2inv * (-c * c * dL_dconic.x + 2 * b * c * dL_dconic.y + (denom - a * c) * dL_dconic.z);
+		dL_dc = denom2inv * (-a * a * dL_dconic.z + 2 * a * b * dL_dconic.y + (denom - a * c) * dL_dconic.x);
+		dL_db = denom2inv * 2 * (b * c * dL_dconic.x - (denom + 2 * b * b) * dL_dconic.y + a * b * dL_dconic.z);
+
+		// Gradients of loss L w.r.t. each 3D covariance matrix (Vrk) entry, 
+		// given gradients w.r.t. 2D covariance matrix (diagonal).
+		// cov2D = transpose(T) * transpose(Vrk) * T;
+		dL_dcov[6 * idx + 0] = (T[0][0] * T[0][0] * dL_da + T[0][0] * T[1][0] * dL_db + T[1][0] * T[1][0] * dL_dc);
+		dL_dcov[6 * idx + 3] = (T[0][1] * T[0][1] * dL_da + T[0][1] * T[1][1] * dL_db + T[1][1] * T[1][1] * dL_dc);
+		dL_dcov[6 * idx + 5] = (T[0][2] * T[0][2] * dL_da + T[0][2] * T[1][2] * dL_db + T[1][2] * T[1][2] * dL_dc);
+
+		// Gradients of loss L w.r.t. each 3D covariance matrix (Vrk) entry, 
+		// given gradients w.r.t. 2D covariance matrix (off-diagonal).
+		// Off-diagonal elements appear twice --> double the gradient.
+		// cov2D = transpose(T) * transpose(Vrk) * T;
+		dL_dcov[6 * idx + 1] = 2 * T[0][0] * T[0][1] * dL_da + (T[0][0] * T[1][1] + T[0][1] * T[1][0]) * dL_db + 2 * T[1][0] * T[1][1] * dL_dc;
+		dL_dcov[6 * idx + 2] = 2 * T[0][0] * T[0][2] * dL_da + (T[0][0] * T[1][2] + T[0][2] * T[1][0]) * dL_db + 2 * T[1][0] * T[1][2] * dL_dc;
+		dL_dcov[6 * idx + 4] = 2 * T[0][2] * T[0][1] * dL_da + (T[0][1] * T[1][2] + T[0][2] * T[1][1]) * dL_db + 2 * T[1][1] * T[1][2] * dL_dc;
+	}
+	else
+	{
+		for (int i = 0; i < 6; i++)
+			dL_dcov[6 * idx + i] = 0;
+	}
+
+	// Gradients of loss w.r.t. upper 2x3 portion of intermediate matrix T
+	// cov2D = transpose(T) * transpose(Vrk) * T;
+	float dL_dT00 = 2 * (T[0][0] * Vrk[0][0] + T[0][1] * Vrk[0][1] + T[0][2] * Vrk[0][2]) * dL_da +
+		(T[1][0] * Vrk[0][0] + T[1][1] * Vrk[0][1] + T[1][2] * Vrk[0][2]) * dL_db;
+	float dL_dT01 = 2 * (T[0][0] * Vrk[1][0] + T[0][1] * Vrk[1][1] + T[0][2] * Vrk[1][2]) * dL_da +
+		(T[1][0] * Vrk[1][0] + T[1][1] * Vrk[1][1] + T[1][2] * Vrk[1][2]) * dL_db;
+	float dL_dT02 = 2 * (T[0][0] * Vrk[2][0] + T[0][1] * Vrk[2][1] + T[0][2] * Vrk[2][2]) * dL_da +
+		(T[1][0] * Vrk[2][0] + T[1][1] * Vrk[2][1] + T[1][2] * Vrk[2][2]) * dL_db;
+	float dL_dT10 = 2 * (T[1][0] * Vrk[0][0] + T[1][1] * Vrk[0][1] + T[1][2] * Vrk[0][2]) * dL_dc +
+		(T[0][0] * Vrk[0][0] + T[0][1] * Vrk[0][1] + T[0][2] * Vrk[0][2]) * dL_db;
+	float dL_dT11 = 2 * (T[1][0] * Vrk[1][0] + T[1][1] * Vrk[1][1] + T[1][2] * Vrk[1][2]) * dL_dc +
+		(T[0][0] * Vrk[1][0] + T[0][1] * Vrk[1][1] + T[0][2] * Vrk[1][2]) * dL_db;
+	float dL_dT12 = 2 * (T[1][0] * Vrk[2][0] + T[1][1] * Vrk[2][1] + T[1][2] * Vrk[2][2]) * dL_dc +
+		(T[0][0] * Vrk[2][0] + T[0][1] * Vrk[2][1] + T[0][2] * Vrk[2][2]) * dL_db;
+
+	// Gradients of loss w.r.t. upper 3x2 non-zero entries of Jacobian matrix
+	// T = W * J
+	float dL_dJ00 = W[0][0] * dL_dT00 + W[0][1] * dL_dT01 + W[0][2] * dL_dT02;
+	float dL_dJ02 = W[2][0] * dL_dT00 + W[2][1] * dL_dT01 + W[2][2] * dL_dT02;
+	float dL_dJ11 = W[1][0] * dL_dT10 + W[1][1] * dL_dT11 + W[1][2] * dL_dT12;
+	float dL_dJ12 = W[2][0] * dL_dT10 + W[2][1] * dL_dT11 + W[2][2] * dL_dT12;
+
+	float tz = 1.f / t.z;
+	float tz2 = tz * tz;
+	float tz3 = tz2 * tz;
+
+	// Gradients of loss w.r.t. transformed Gaussian mean t
+	float dL_dtx = x_grad_mul * -h_x * tz2 * dL_dJ02;
+	float dL_dty = y_grad_mul * -h_y * tz2 * dL_dJ12;
+	float dL_dtz = -h_x * tz2 * dL_dJ00 - h_y * tz2 * dL_dJ11 + (2 * h_x * t.x) * tz3 * dL_dJ02 + (2 * h_y * t.y) * tz3 * dL_dJ12;
+
+	// Account for transformation of mean to t
+	// t = transformPoint4x3(mean, view_matrix);
+	float3 dL_dmean = transformVec4x3Transpose({ dL_dtx, dL_dty, dL_dtz }, view_matrix);
+
+	// Gradients of loss w.r.t. Gaussian means, but only the portion 
+	// that is caused because the mean affects the covariance matrix.
+	// Additional mean gradient is accumulated in BACKWARD::preprocess.
+	dL_dmeans[idx] = dL_dmean;
+}
+
+// Backward pass for the conversion of scale and rotation to a 
+// 3D covariance matrix for each Gaussian. 
+__device__ void computeCov3D(int idx, const glm::vec3 scale, float mod, const glm::vec4 rot, const float* dL_dcov3Ds, glm::vec3* dL_dscales, glm::vec4* dL_drots)
+{
+	// Recompute (intermediate) results for the 3D covariance computation.
+	glm::vec4 q = rot;// / glm::length(rot);
+	float r = q.x;
+	float x = q.y;
+	float y = q.z;
+	float z = q.w;
+
+	glm::mat3 R = glm::mat3(
+		1.f - 2.f * (y * y + z * z), 2.f * (x * y - r * z), 2.f * (x * z + r * y),
+		2.f * (x * y + r * z), 1.f - 2.f * (x * x + z * z), 2.f * (y * z - r * x),
+		2.f * (x * z - r * y), 2.f * (y * z + r * x), 1.f - 2.f * (x * x + y * y)
+	);
+
+	glm::mat3 S = glm::mat3(1.0f);
+
+	glm::vec3 s = mod * scale;
+	S[0][0] = s.x;
+	S[1][1] = s.y;
+	S[2][2] = s.z;
+
+	glm::mat3 M = S * R;
+
+	const float* dL_dcov3D = dL_dcov3Ds + 6 * idx;
+
+	glm::vec3 dunc(dL_dcov3D[0], dL_dcov3D[3], dL_dcov3D[5]);
+	glm::vec3 ounc = 0.5f * glm::vec3(dL_dcov3D[1], dL_dcov3D[2], dL_dcov3D[4]);
+
+	// Convert per-element covariance loss gradients to matrix form
+	glm::mat3 dL_dSigma = glm::mat3(
+		dL_dcov3D[0], 0.5f * dL_dcov3D[1], 0.5f * dL_dcov3D[2],
+		0.5f * dL_dcov3D[1], dL_dcov3D[3], 0.5f * dL_dcov3D[4],
+		0.5f * dL_dcov3D[2], 0.5f * dL_dcov3D[4], dL_dcov3D[5]
+	);
+
+	// Compute loss gradient w.r.t. matrix M
+	// dSigma_dM = 2 * M
+	glm::mat3 dL_dM = 2.0f * M * dL_dSigma;
+
+	glm::mat3 Rt = glm::transpose(R);
+	glm::mat3 dL_dMt = glm::transpose(dL_dM);
+
+	// Gradients of loss w.r.t. scale
+	glm::vec3* dL_dscale = dL_dscales + idx;
+	dL_dscale->x = glm::dot(Rt[0], dL_dMt[0]);
+	dL_dscale->y = glm::dot(Rt[1], dL_dMt[1]);
+	dL_dscale->z = glm::dot(Rt[2], dL_dMt[2]);
+
+	dL_dMt[0] *= s.x;
+	dL_dMt[1] *= s.y;
+	dL_dMt[2] *= s.z;
+
+	// Gradients of loss w.r.t. normalized quaternion
+	glm::vec4 dL_dq;
+	dL_dq.x = 2 * z * (dL_dMt[0][1] - dL_dMt[1][0]) + 2 * y * (dL_dMt[2][0] - dL_dMt[0][2]) + 2 * x * (dL_dMt[1][2] - dL_dMt[2][1]);
+	dL_dq.y = 2 * y * (dL_dMt[1][0] + dL_dMt[0][1]) + 2 * z * (dL_dMt[2][0] + dL_dMt[0][2]) + 2 * r * (dL_dMt[1][2] - dL_dMt[2][1]) - 4 * x * (dL_dMt[2][2] + dL_dMt[1][1]);
+	dL_dq.z = 2 * x * (dL_dMt[1][0] + dL_dMt[0][1]) + 2 * r * (dL_dMt[2][0] - dL_dMt[0][2]) + 2 * z * (dL_dMt[1][2] + dL_dMt[2][1]) - 4 * y * (dL_dMt[2][2] + dL_dMt[0][0]);
+	dL_dq.w = 2 * r * (dL_dMt[0][1] - dL_dMt[1][0]) + 2 * x * (dL_dMt[2][0] + dL_dMt[0][2]) + 2 * y * (dL_dMt[1][2] + dL_dMt[2][1]) - 4 * z * (dL_dMt[1][1] + dL_dMt[0][0]);
+
+	// Gradients of loss w.r.t. unnormalized quaternion
+	float4* dL_drot = (float4*)(dL_drots + idx);
+	*dL_drot = float4{ dL_dq.x, dL_dq.y, dL_dq.z, dL_dq.w };//dnormvdv(float4{ rot.x, rot.y, rot.z, rot.w }, float4{ dL_dq.x, dL_dq.y, dL_dq.z, dL_dq.w });
+}
+
+// Backward pass of the preprocessing steps, except
+// for the covariance computation and inversion
+// (those are handled by a previous kernel call)
+template<int C>
+__global__ void preprocessCUDA(
+	int P, int D, int M,
+	const float3* means,
+	const int* radii,
+	const float* dc,
+	const float* shs,
+	const bool* clamped,
+	const glm::vec3* scales,
+	const glm::vec4* rotations,
+	const float scale_modifier,
+	const float* proj,
+	const glm::vec3* campos,
+	const float3* dL_dmean2D,
+	glm::vec3* dL_dmeans,
+	float* dL_dcolor,
+	float* dL_dcov3D,
+	float* dL_ddc,
+	float* dL_dsh,
+	glm::vec3* dL_dscale,
+	glm::vec4* dL_drot)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= P || !(radii[idx] > 0))
+		return;
+
+	float3 m = means[idx];
+
+	// Taking care of gradients from the screenspace points
+	float4 m_hom = transformPoint4x4(m, proj);
+	float m_w = 1.0f / (m_hom.w + 0.0000001f);
+
+	// Compute loss gradient w.r.t. 3D means due to gradients of 2D means
+	// from rendering procedure
+	glm::vec3 dL_dmean;
+	float mul1 = (proj[0] * m.x + proj[4] * m.y + proj[8] * m.z + proj[12]) * m_w * m_w;
+	float mul2 = (proj[1] * m.x + proj[5] * m.y + proj[9] * m.z + proj[13]) * m_w * m_w;
+	dL_dmean.x = (proj[0] * m_w - proj[3] * mul1) * dL_dmean2D[idx].x + (proj[1] * m_w - proj[3] * mul2) * dL_dmean2D[idx].y;
+	dL_dmean.y = (proj[4] * m_w - proj[7] * mul1) * dL_dmean2D[idx].x + (proj[5] * m_w - proj[7] * mul2) * dL_dmean2D[idx].y;
+	dL_dmean.z = (proj[8] * m_w - proj[11] * mul1) * dL_dmean2D[idx].x + (proj[9] * m_w - proj[11] * mul2) * dL_dmean2D[idx].y;
+
+	// That's the second part of the mean gradient. Previous computation
+	// of cov2D and following SH conversion also affects it.
+	dL_dmeans[idx] += dL_dmean;
+
+	// Compute gradient updates due to computing colors from SHs
+	if (shs)
+		computeColorFromSH(idx, D, M, (glm::vec3*)means, *campos, dc, shs, clamped, (glm::vec3*)dL_dcolor, (glm::vec3*)dL_dmeans, (glm::vec3*)dL_ddc, (glm::vec3*)dL_dsh);
+
+	// Compute gradient updates due to computing covariance from scale/rotation
+	if (scales)
+		computeCov3D(idx, scales[idx], scale_modifier, rotations[idx], dL_dcov3D, dL_dscale, dL_drot);
+}
+
+template<uint32_t C>
+__global__ void
+PerGaussianRenderCUDA(
+	const uint2* __restrict__ ranges,
+	const uint32_t* __restrict__ point_list,
+	int W, int H, int B,
+	const uint32_t* __restrict__ per_tile_bucket_offset,
+	const uint32_t* __restrict__ bucket_to_tile,
+	const float* __restrict__ sampled_T, const float* __restrict__ sampled_ar,
+	const float* __restrict__ bg_color,
+	const float2* __restrict__ points_xy_image,
+	const float4* __restrict__ conic_opacity,
+	const float* __restrict__ colors,
+	const float* __restrict__ final_Ts,
+	const uint32_t* __restrict__ n_contrib,
+	const uint32_t* __restrict__ max_contrib,
+	const float* __restrict__ pixel_colors,
+	const float* __restrict__ dL_dpixels,
+	float3* __restrict__ dL_dmean2D,
+	float4* __restrict__ dL_dconic2D,
+	float* __restrict__ dL_dopacity,
+	float* __restrict__ dL_dcolors
+) {
+	// global_bucket_idx = warp_idx
+	auto block = cg::this_thread_block();
+	auto my_warp = cg::tiled_partition<32>(block);
+	uint32_t global_bucket_idx = block.group_index().x * my_warp.meta_group_size() + my_warp.meta_group_rank();
+	bool valid_bucket = global_bucket_idx < (uint32_t) B;
+	if (!valid_bucket) return;
+
+	bool valid_splat = false;
+
+	uint32_t tile_id, bbm;
+	uint2 range;
+	int num_splats_in_tile, bucket_idx_in_tile;
+	int splat_idx_in_tile, splat_idx_global;
+
+	tile_id = bucket_to_tile[global_bucket_idx];
+	range = ranges[tile_id];
+	num_splats_in_tile = range.y - range.x;
+	// What is the number of buckets before me? what is my offset?
+	bbm = tile_id == 0 ? 0 : per_tile_bucket_offset[tile_id - 1];
+	bucket_idx_in_tile = global_bucket_idx - bbm;
+	splat_idx_in_tile = bucket_idx_in_tile * 32 + my_warp.thread_rank();
+	splat_idx_global = range.x + splat_idx_in_tile;
+	valid_splat = (splat_idx_in_tile < num_splats_in_tile);
+
+	// if first gaussian in bucket is useless, then others are also useless
+	if (bucket_idx_in_tile * 32 >= max_contrib[tile_id]) {
+		return;
+	}
+
+	// Load Gaussian properties into registers
+	int gaussian_idx = 0;
+	float2 xy = {0.0f, 0.0f};
+	float4 con_o = {0.0f, 0.0f, 0.0f, 0.0f};
+	float c[C] = {0.0f};
+	if (valid_splat) {
+		gaussian_idx = point_list[splat_idx_global];
+		xy = points_xy_image[gaussian_idx];
+		con_o = conic_opacity[gaussian_idx];
+		for (int ch = 0; ch < C; ++ch)
+			c[ch] = colors[gaussian_idx * C + ch];
+	}
+
+	// Gradient accumulation variables
+	float Register_dL_dmean2D_x = 0.0f;
+	float Register_dL_dmean2D_y = 0.0f;
+	float Register_dL_dconic2D_x = 0.0f;
+	float Register_dL_dconic2D_y = 0.0f;
+	float Register_dL_dconic2D_w = 0.0f;
+	float Register_dL_dopacity = 0.0f;
+	float Register_dL_dcolors[C] = {0.0f};
+	
+	// tile metadata
+	const uint32_t horizontal_blocks = (W + BLOCK_X - 1) / BLOCK_X;
+	const uint2 tile = {tile_id % horizontal_blocks, tile_id / horizontal_blocks};
+	const uint2 pix_min = {tile.x * BLOCK_X, tile.y * BLOCK_Y};
+
+	// values useful for gradient calculation
+	float T;
+	float T_final;
+	float last_contributor;
+	float ar[C];
+	float dL_dpixel[C];
+	const float ddelx_dx = 0.5 * W;
+	const float ddely_dy = 0.5 * H;
+
+  // shared memory
+  __shared__ float Shared_sampled_ar[32 * C + 1];
+  sampled_ar += global_bucket_idx * BLOCK_SIZE * C;
+  __shared__ float Shared_pixels[32 * C];
+
+	// iterate over all pixels in the tile
+  	#pragma unroll
+	for (int i = 0; i < BLOCK_SIZE + 31; ++i) {
+    if (i % 32 == 0) {
+      for (int ch = 0; ch < C; ++ch) {
+        int shift = BLOCK_SIZE * ch + i + block.thread_rank();
+        Shared_sampled_ar[ch * 32 + block.thread_rank()] = sampled_ar[shift];
+      }
+      const uint32_t local_id = i + block.thread_rank();
+      const uint2 pix = {pix_min.x + local_id % BLOCK_X, pix_min.y + local_id / BLOCK_X};
+      const uint32_t id = W * pix.y + pix.x;
+      for (int ch = 0; ch < C; ++ch) {
+        Shared_pixels[ch * 32 + block.thread_rank()] = pixel_colors[ch * H * W + id];
+      }
+      block.sync();
+    }
+
+		// SHUFFLING
+
+		// At this point, T already has my (1 - alpha) multiplied.
+		// So pass this ready-made T value to next thread.
+		T = my_warp.shfl_up(T, 1);
+		last_contributor = my_warp.shfl_up(last_contributor, 1);
+		T_final = my_warp.shfl_up(T_final, 1);
+		for (int ch = 0; ch < C; ++ch) {
+			ar[ch] = my_warp.shfl_up(ar[ch], 1);
+			dL_dpixel[ch] = my_warp.shfl_up(dL_dpixel[ch], 1);
+		}
+
+		// which pixel index should this thread deal with?
+		int idx = i - my_warp.thread_rank();
+		const uint2 pix = {pix_min.x + idx % BLOCK_X, pix_min.y + idx / BLOCK_X};
+		const uint32_t pix_id = W * pix.y + pix.x;
+		const float2 pixf = {(float) pix.x, (float) pix.y};
+		bool valid_pixel = pix.x < W && pix.y < H;
+		
+		// every 32nd thread should read the stored state from memory
+		// TODO: perhaps store these things in shared memory?
+		if (valid_splat && valid_pixel && my_warp.thread_rank() == 0 && idx < BLOCK_SIZE) {
+			T = sampled_T[global_bucket_idx * BLOCK_SIZE + idx];
+      		int ii = i % 32;
+			for (int ch = 0; ch < C; ++ch) 
+				ar[ch] = -Shared_pixels[ch * 32 + ii] + Shared_sampled_ar[ch * 32 + ii];
+			T_final = final_Ts[pix_id];
+			last_contributor = n_contrib[pix_id];
+			for (int ch = 0; ch < C; ++ch) {
+				dL_dpixel[ch] = dL_dpixels[ch * H * W + pix_id];
+			}
+		}
+
+		// do work
+		if (valid_splat && valid_pixel && 0 <= idx && idx < BLOCK_SIZE) {
+			if (W <= pix.x || H <= pix.y) continue;
+
+			if (splat_idx_in_tile >= last_contributor) continue;
+
+			// compute blending values
+			const float2 d = { xy.x - pixf.x, xy.y - pixf.y };
+			const float power = -0.5f * (con_o.x * d.x * d.x + con_o.z * d.y * d.y) - con_o.y * d.x * d.y;
+			if (power > 0.0f) continue;
+			const float G = exp(power);
+			const float alpha = min(0.99f, con_o.w * G);
+			if (alpha < 1.0f / 255.0f) continue;
+			const float dchannel_dcolor = alpha * T;
+	        const float one_minus_alpha_reci = 1.0f / (1.0f - alpha);
+
+			// add the gradient contribution of this pixel to the gaussian
+			float dL_dalpha = 0.0f;
+			for (int ch = 0; ch < C; ++ch) {
+				ar[ch] += dchannel_dcolor * c[ch];
+				const float &dL_dchannel = dL_dpixel[ch];
+				Register_dL_dcolors[ch] += dchannel_dcolor * dL_dchannel;
+				dL_dalpha += (c[ch] * T + one_minus_alpha_reci * ar[ch]) * dL_dchannel;
+			}
+			float bg_dot_dpixel = 0.0f;
+			for (int ch = 0; ch < C; ++ch) {
+				bg_dot_dpixel += bg_color[ch] * dL_dpixel[ch];
+			}
+			dL_dalpha += (-T_final * one_minus_alpha_reci) * bg_dot_dpixel;
+			T *= (1.0f - alpha);
+
+
+			// Helpful reusable temporary variables
+			const float dL_dG = con_o.w * dL_dalpha;
+			const float gdx = G * d.x;
+			const float gdy = G * d.y;
+			const float dG_ddelx = -gdx * con_o.x - gdy * con_o.y;
+			const float dG_ddely = -gdy * con_o.z - gdx * con_o.y;
+
+			// accumulate the gradients
+			const float tmp_x = dL_dG * dG_ddelx * ddelx_dx;
+			Register_dL_dmean2D_x += tmp_x;
+			const float tmp_y = dL_dG * dG_ddely * ddely_dy;
+			Register_dL_dmean2D_y += tmp_y;
+
+			Register_dL_dconic2D_x += -0.5f * gdx * d.x * dL_dG;
+			Register_dL_dconic2D_y += -0.5f * gdx * d.y * dL_dG;
+			Register_dL_dconic2D_w += -0.5f * gdy * d.y * dL_dG;
+			Register_dL_dopacity += G * dL_dalpha;
+		}
+	}
+
+	// finally add the gradients using atomics
+	if (valid_splat) {
+		atomicAdd(&dL_dmean2D[gaussian_idx].x, Register_dL_dmean2D_x);
+		atomicAdd(&dL_dmean2D[gaussian_idx].y, Register_dL_dmean2D_y);
+		atomicAdd(&dL_dconic2D[gaussian_idx].x, Register_dL_dconic2D_x);
+		atomicAdd(&dL_dconic2D[gaussian_idx].y, Register_dL_dconic2D_y);
+		atomicAdd(&dL_dconic2D[gaussian_idx].w, Register_dL_dconic2D_w);
+		atomicAdd(&dL_dopacity[gaussian_idx], Register_dL_dopacity);
+		for (int ch = 0; ch < C; ++ch) {
+			atomicAdd(&dL_dcolors[gaussian_idx * C + ch], Register_dL_dcolors[ch]);
+		}
+	}
+}
+
+// Backward version of the rendering procedure.
+template <uint32_t C>
+__global__ void __launch_bounds__(BLOCK_X * BLOCK_Y)
+renderCUDA(
+	const uint2* __restrict__ ranges,
+	const uint32_t* __restrict__ point_list,
+	int W, int H,
+	const float* __restrict__ bg_color,
+	const float2* __restrict__ points_xy_image,
+	const float4* __restrict__ conic_opacity,
+	const float* __restrict__ colors,
+	const float* __restrict__ final_Ts,
+	const uint32_t* __restrict__ n_contrib,
+	const float* __restrict__ dL_dpixels,
+	float3* __restrict__ dL_dmean2D,
+	float4* __restrict__ dL_dconic2D,
+	float* __restrict__ dL_dopacity,
+	float* __restrict__ dL_dcolors)
+{
+	// We rasterize again. Compute necessary block info.
+	auto block = cg::this_thread_block();
+	const uint32_t horizontal_blocks = (W + BLOCK_X - 1) / BLOCK_X;
+	const uint2 pix_min = { block.group_index().x * BLOCK_X, block.group_index().y * BLOCK_Y };
+	const uint2 pix_max = { min(pix_min.x + BLOCK_X, W), min(pix_min.y + BLOCK_Y , H) };
+	const uint2 pix = { pix_min.x + block.thread_index().x, pix_min.y + block.thread_index().y };
+	const uint32_t pix_id = W * pix.y + pix.x;
+	const float2 pixf = { (float)pix.x, (float)pix.y };
+
+	const bool inside = pix.x < W&& pix.y < H;
+	const uint2 range = ranges[block.group_index().y * horizontal_blocks + block.group_index().x];
+
+	const int rounds = ((range.y - range.x + BLOCK_SIZE - 1) / BLOCK_SIZE);
+
+	bool done = !inside;
+	int toDo = range.y - range.x;
+
+	__shared__ int collected_id[BLOCK_SIZE];
+	__shared__ float2 collected_xy[BLOCK_SIZE];
+	__shared__ float4 collected_conic_opacity[BLOCK_SIZE];
+	__shared__ float collected_colors[C * BLOCK_SIZE];
+
+	// In the forward, we stored the final value for T, the
+	// product of all (1 - alpha) factors. 
+	const float T_final = inside ? final_Ts[pix_id] : 0;
+	float T = T_final;
+
+	// We start from the back. The ID of the last contributing
+	// Gaussian is known from each pixel from the forward.
+	uint32_t contributor = toDo;
+	const int last_contributor = inside ? n_contrib[pix_id] : 0;
+
+	float accum_rec[C] = { 0 };
+	float dL_dpixel[C];
+	if (inside)
+		for (int i = 0; i < C; i++)
+			dL_dpixel[i] = dL_dpixels[i * H * W + pix_id];
+
+	float last_alpha = 0;
+	float last_color[C] = { 0 };
+
+	// Gradient of pixel coordinate w.r.t. normalized 
+	// screen-space viewport corrdinates (-1 to 1)
+	const float ddelx_dx = 0.5 * W;
+	const float ddely_dy = 0.5 * H;
+
+	// Traverse all Gaussians
+	for (int i = 0; i < rounds; i++, toDo -= BLOCK_SIZE)
+	{
+		// Load auxiliary data into shared memory, start in the BACK
+		// and load them in revers order.
+		block.sync();
+		const int progress = i * BLOCK_SIZE + block.thread_rank();
+		if (range.x + progress < range.y)
+		{
+			const int coll_id = point_list[range.y - progress - 1];
+			collected_id[block.thread_rank()] = coll_id;
+			collected_xy[block.thread_rank()] = points_xy_image[coll_id];
+			collected_conic_opacity[block.thread_rank()] = conic_opacity[coll_id];
+			for (int i = 0; i < C; i++)
+				collected_colors[i * BLOCK_SIZE + block.thread_rank()] = colors[coll_id * C + i];
+		}
+		block.sync();
+
+		// Iterate over Gaussians
+		for (int j = 0; !done && j < min(BLOCK_SIZE, toDo); j++)
+		{
+			// Keep track of current Gaussian ID. Skip, if this one
+			// is behind the last contributor for this pixel.
+			contributor--;
+			if (contributor >= last_contributor)
+				continue;
+
+			// Compute blending values, as before.
+			const float2 xy = collected_xy[j];
+			const float2 d = { xy.x - pixf.x, xy.y - pixf.y };
+			const float4 con_o = collected_conic_opacity[j];
+			const float power = -0.5f * (con_o.x * d.x * d.x + con_o.z * d.y * d.y) - con_o.y * d.x * d.y;
+			if (power > 0.0f)
+				continue;
+
+			const float G = exp(power);
+			const float alpha = min(0.99f, con_o.w * G);
+			if (alpha < 1.0f / 255.0f)
+				continue;
+
+			T = T / (1.f - alpha);
+			const float dchannel_dcolor = alpha * T;
+
+			// Propagate gradients to per-Gaussian colors and keep
+			// gradients w.r.t. alpha (blending factor for a Gaussian/pixel
+			// pair).
+			float dL_dalpha = 0.0f;
+			const int global_id = collected_id[j];
+			for (int ch = 0; ch < C; ch++)
+			{
+				const float c = collected_colors[ch * BLOCK_SIZE + j];
+				// Update last color (to be used in the next iteration)
+				accum_rec[ch] = last_alpha * last_color[ch] + (1.f - last_alpha) * accum_rec[ch];
+				last_color[ch] = c;
+
+				const float dL_dchannel = dL_dpixel[ch];
+				dL_dalpha += (c - accum_rec[ch]) * dL_dchannel;
+				// Update the gradients w.r.t. color of the Gaussian. 
+				// Atomic, since this pixel is just one of potentially
+				// many that were affected by this Gaussian.
+				atomicAdd(&(dL_dcolors[global_id * C + ch]), dchannel_dcolor * dL_dchannel);
+			}
+			dL_dalpha *= T;
+			// Update last alpha (to be used in the next iteration)
+			last_alpha = alpha;
+
+			// Account for fact that alpha also influences how much of
+			// the background color is added if nothing left to blend
+			float bg_dot_dpixel = 0;
+			for (int i = 0; i < C; i++)
+				bg_dot_dpixel += bg_color[i] * dL_dpixel[i];
+			dL_dalpha += (-T_final / (1.f - alpha)) * bg_dot_dpixel;
+
+
+			// Helpful reusable temporary variables
+			const float dL_dG = con_o.w * dL_dalpha;
+			const float gdx = G * d.x;
+			const float gdy = G * d.y;
+			const float dG_ddelx = -gdx * con_o.x - gdy * con_o.y;
+			const float dG_ddely = -gdy * con_o.z - gdx * con_o.y;
+
+			if(con_o.w*G > 0.99f){
+				continue;
+			}
+
+			// Update gradients w.r.t. 2D mean position of the Gaussian
+			atomicAdd(&dL_dmean2D[global_id].x, dL_dG * dG_ddelx * ddelx_dx);
+			atomicAdd(&dL_dmean2D[global_id].y, dL_dG * dG_ddely * ddely_dy);
+
+			// Update gradients w.r.t. 2D covariance (2x2 matrix, symmetric)
+			atomicAdd(&dL_dconic2D[global_id].x, -0.5f * gdx * d.x * dL_dG);
+			atomicAdd(&dL_dconic2D[global_id].y, -0.5f * gdx * d.y * dL_dG);
+			atomicAdd(&dL_dconic2D[global_id].w, -0.5f * gdy * d.y * dL_dG);
+
+			// Update gradients w.r.t. opacity of the Gaussian
+			atomicAdd(&(dL_dopacity[global_id]), G * dL_dalpha);
+		}
+	}
+}
+
+void BACKWARD::preprocess(
+	int P, int D, int M,
+	const float3* means3D,
+	const int* radii,
+	const float* dc,
+	const float* shs,
+	const bool* clamped,
+	const glm::vec3* scales,
+	const glm::vec4* rotations,
+	const float scale_modifier,
+	const float* cov3Ds,
+	const float* viewmatrix,
+	const float* projmatrix,
+	const float focal_x, float focal_y,
+	const float tan_fovx, float tan_fovy,
+	const glm::vec3* campos,
+	const float3* dL_dmean2D,
+	const float* dL_dconic,
+	glm::vec3* dL_dmean3D,
+	float* dL_dcolor,
+	float* dL_dcov3D,
+	float* dL_ddc,
+	float* dL_dsh,
+	glm::vec3* dL_dscale,
+	glm::vec4* dL_drot)
+{
+	// Propagate gradients for the path of 2D conic matrix computation. 
+	// Somewhat long, thus it is its own kernel rather than being part of 
+	// "preprocess". When done, loss gradient w.r.t. 3D means has been
+	// modified and gradient w.r.t. 3D covariance matrix has been computed.	
+	computeCov2DCUDA << <(P + 255) / 256, 256 >> > (
+		P,
+		means3D,
+		radii,
+		cov3Ds,
+		focal_x,
+		focal_y,
+		tan_fovx,
+		tan_fovy,
+		viewmatrix,
+		dL_dconic,
+		(float3*)dL_dmean3D,
+		dL_dcov3D);
+
+	// Propagate gradients for remaining steps: finish 3D mean gradients,
+	// propagate color gradients to SH (if desireD), propagate 3D covariance
+	// matrix gradients to scale and rotation.
+	preprocessCUDA<NUM_CHAFFELS> << < (P + 255) / 256, 256 >> > (
+		P, D, M,
+		(float3*)means3D,
+		radii,
+		dc,
+		shs,
+		clamped,
+		(glm::vec3*)scales,
+		(glm::vec4*)rotations,
+		scale_modifier,
+		projmatrix,
+		campos,
+		(float3*)dL_dmean2D,
+		(glm::vec3*)dL_dmean3D,
+		dL_dcolor,
+		dL_dcov3D,
+		dL_ddc,
+		dL_dsh,
+		dL_dscale,
+		dL_drot);
+}
+
+void BACKWARD::render(
+	const dim3 grid, dim3 block,
+	const uint2* ranges,
+	const uint32_t* point_list,
+	int W, int H, int R, int B,
+	const uint32_t* per_bucket_tile_offset,
+	const uint32_t* bucket_to_tile,
+	const float* sampled_T, const float* sampled_ar,
+	const float* bg_color,
+	const float2* means2D,
+	const float4* conic_opacity,
+	const float* colors,
+	const float* final_Ts,
+	const uint32_t* n_contrib,
+	const uint32_t* max_contrib,
+	const float* pixel_colors,
+	const float* dL_dpixels,
+	float3* dL_dmean2D,
+	float4* dL_dconic2D,
+	float* dL_dopacity,
+	float* dL_dcolors)
+{
+	const int THREADS = 32;
+	PerGaussianRenderCUDA<NUM_CHAFFELS> <<<((B*32) + THREADS - 1) / THREADS,THREADS>>>(
+		ranges,
+		point_list,
+		W, H, B,
+		per_bucket_tile_offset,
+		bucket_to_tile,
+		sampled_T, sampled_ar,
+		bg_color,
+		means2D,
+		conic_opacity,
+		colors,
+		final_Ts,
+		n_contrib,
+		max_contrib,
+		pixel_colors,
+		dL_dpixels,
+		dL_dmean2D,
+		dL_dconic2D,
+		dL_dopacity,
+		dL_dcolors
+		);
+}

--- a/taminggs/backward.h
+++ b/taminggs/backward.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#ifndef CUDA_RASTERIZER_BACKWARD_H_INCLUDED
+#define CUDA_RASTERIZER_BACKWARD_H_INCLUDED
+
+#include <cuda.h>
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+#define GLM_FORCE_CUDA
+#include <glm/glm.hpp>
+
+namespace BACKWARD
+{
+	void render(
+		const dim3 grid, dim3 block,
+		const uint2* ranges,
+		const uint32_t* point_list,
+		int W, int H, int R, int B,
+		const uint32_t* per_bucket_tile_offset,
+		const uint32_t* bucket_to_tile,
+		const float* sampled_T, const float* sampled_ar,
+		const float* bg_color,
+		const float2* means2D,
+		const float4* conic_opacity,
+		const float* colors,
+		const float* final_Ts,
+		const uint32_t* n_contrib,
+		const uint32_t* max_contrib,
+		const float* pixel_colors,
+		const float* dL_dpixels,
+		float3* dL_dmean2D,
+		float4* dL_dconic2D,
+		float* dL_dopacity,
+		float* dL_dcolors);
+
+	void preprocess(
+		int P, int D, int M,
+		const float3* means,
+		const int* radii,
+		const float* dc,
+		const float* shs,
+		const bool* clamped,
+		const glm::vec3* scales,
+		const glm::vec4* rotations,
+		const float scale_modifier,
+		const float* cov3Ds,
+		const float* view,
+		const float* proj,
+		const float focal_x, float focal_y,
+		const float tan_fovx, float tan_fovy,
+		const glm::vec3* campos,
+		const float3* dL_dmean2D,
+		const float* dL_dconics,
+		glm::vec3* dL_dmeans,
+		float* dL_dcolor,
+		float* dL_dcov3D,
+		float* dL_ddc,
+		float* dL_dsh,
+		glm::vec3* dL_dscale,
+		glm::vec4* dL_drot);
+}
+
+#endif

--- a/taminggs/config.h
+++ b/taminggs/config.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#ifndef CUDA_RASTERIZER_CONFIG_H_INCLUDED
+#define CUDA_RASTERIZER_CONFIG_H_INCLUDED
+
+#define NUM_CHAFFELS 3 // Default 3, RGB
+#define BLOCK_X 16
+#define BLOCK_Y 16
+
+#endif

--- a/taminggs/forward.cu
+++ b/taminggs/forward.cu
@@ -1,0 +1,590 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#include "forward.h"
+#include "auxiliary.h"
+#include <cuda.h>
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+#include <cub/cub.cuh>
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+namespace cg = cooperative_groups;
+
+// Forward method for converting the input spherical harmonics
+// coefficients of each Gaussian to a simple RGB color.
+__device__ glm::vec3 computeColorFromSH(int idx, int deg, int max_coeffs, const glm::vec3* means, glm::vec3 campos, const float* dc, const float* shs, bool* clamped)
+{
+	// The implementation is loosely based on code for 
+	// "Differentiable Point-Based Radiance Fields for 
+	// Efficient View Synthesis" by Zhang et al. (2022)
+	glm::vec3 pos = means[idx];
+	glm::vec3 dir = pos - campos;
+	dir = dir / glm::length(dir);
+
+	glm::vec3* direct_color = ((glm::vec3*)dc) + idx;
+	glm::vec3* sh = ((glm::vec3*)shs) + idx * max_coeffs;
+	glm::vec3 result = SH_C0 * direct_color[0];
+
+	if (deg > 0)
+	{
+		float x = dir.x;
+		float y = dir.y;
+		float z = dir.z;
+		result = result - SH_C1 * y * sh[0] + SH_C1 * z * sh[1] - SH_C1 * x * sh[2];
+
+		if (deg > 1)
+		{
+			float xx = x * x, yy = y * y, zz = z * z;
+			float xy = x * y, yz = y * z, xz = x * z;
+			result = result +
+				SH_C2[0] * xy * sh[3] +
+				SH_C2[1] * yz * sh[4] +
+				SH_C2[2] * (2.0f * zz - xx - yy) * sh[5] +
+				SH_C2[3] * xz * sh[6] +
+				SH_C2[4] * (xx - yy) * sh[7];
+
+			if (deg > 2)
+			{
+				result = result +
+					SH_C3[0] * y * (3.0f * xx - yy) * sh[8] +
+					SH_C3[1] * xy * z * sh[9] +
+					SH_C3[2] * y * (4.0f * zz - xx - yy) * sh[10] +
+					SH_C3[3] * z * (2.0f * zz - 3.0f * xx - 3.0f * yy) * sh[11] +
+					SH_C3[4] * x * (4.0f * zz - xx - yy) * sh[12] +
+					SH_C3[5] * z * (xx - yy) * sh[13] +
+					SH_C3[6] * x * (xx - 3.0f * yy) * sh[14];
+			}
+		}
+	}
+	result += 0.5f;
+
+	// RGB colors are clamped to positive values. If values are
+	// clamped, we need to keep track of this for the backward pass.
+	clamped[3 * idx + 0] = (result.x < 0);
+	clamped[3 * idx + 1] = (result.y < 0);
+	clamped[3 * idx + 2] = (result.z < 0);
+	return glm::max(result, 0.0f);
+}
+
+// Forward version of 2D covariance matrix computation
+__device__ float3 computeCov2D(const float3& mean, float focal_x, float focal_y, float tan_fovx, float tan_fovy, const float* cov3D, const float* viewmatrix)
+{
+	// The following models the steps outlined by equations 29
+	// and 31 in "EWA Splatting" (Zwicker et al., 2002). 
+	// Additionally considers aspect / scaling of viewport.
+	// Transposes used to account for row-/column-major conventions.
+	float3 t = transformPoint4x3(mean, viewmatrix);
+
+	const float limx = 1.3f * tan_fovx;
+	const float limy = 1.3f * tan_fovy;
+	const float txtz = t.x / t.z;
+	const float tytz = t.y / t.z;
+	t.x = min(limx, max(-limx, txtz)) * t.z;
+	t.y = min(limy, max(-limy, tytz)) * t.z;
+
+	glm::mat3 J = glm::mat3(
+		focal_x / t.z, 0.0f, -(focal_x * t.x) / (t.z * t.z),
+		0.0f, focal_y / t.z, -(focal_y * t.y) / (t.z * t.z),
+		0, 0, 0);
+
+	glm::mat3 W = glm::mat3(
+		viewmatrix[0], viewmatrix[4], viewmatrix[8],
+		viewmatrix[1], viewmatrix[5], viewmatrix[9],
+		viewmatrix[2], viewmatrix[6], viewmatrix[10]);
+
+	glm::mat3 T = W * J;
+
+	glm::mat3 Vrk = glm::mat3(
+		cov3D[0], cov3D[1], cov3D[2],
+		cov3D[1], cov3D[3], cov3D[4],
+		cov3D[2], cov3D[4], cov3D[5]);
+
+	glm::mat3 cov = glm::transpose(T) * glm::transpose(Vrk) * T;
+
+	// Apply low-pass filter: every Gaussian should be at least
+	// one pixel wide/high. Discard 3rd row and column.
+	cov[0][0] += 0.3f;
+	cov[1][1] += 0.3f;
+	return { float(cov[0][0]), float(cov[0][1]), float(cov[1][1]) };
+}
+
+// Forward method for converting scale and rotation properties of each
+// Gaussian to a 3D covariance matrix in world space. Also takes care
+// of quaternion normalization.
+__device__ void computeCov3D(const glm::vec3 scale, float mod, const glm::vec4 rot, float* cov3D)
+{
+	// Create scaling matrix
+	glm::mat3 S = glm::mat3(1.0f);
+	S[0][0] = mod * scale.x;
+	S[1][1] = mod * scale.y;
+	S[2][2] = mod * scale.z;
+
+	// Normalize quaternion to get valid rotation
+	glm::vec4 q = rot;// / glm::length(rot);
+	float r = q.x;
+	float x = q.y;
+	float y = q.z;
+	float z = q.w;
+
+	// Compute rotation matrix from quaternion
+	glm::mat3 R = glm::mat3(
+		1.f - 2.f * (y * y + z * z), 2.f * (x * y - r * z), 2.f * (x * z + r * y),
+		2.f * (x * y + r * z), 1.f - 2.f * (x * x + z * z), 2.f * (y * z - r * x),
+		2.f * (x * z - r * y), 2.f * (y * z + r * x), 1.f - 2.f * (x * x + y * y)
+	);
+
+	glm::mat3 M = S * R;
+
+	// Compute 3D world covariance matrix Sigma
+	glm::mat3 Sigma = glm::transpose(M) * M;
+
+	// Covariance is symmetric, only store upper right
+	cov3D[0] = Sigma[0][0];
+	cov3D[1] = Sigma[0][1];
+	cov3D[2] = Sigma[0][2];
+	cov3D[3] = Sigma[1][1];
+	cov3D[4] = Sigma[1][2];
+	cov3D[5] = Sigma[2][2];
+}
+
+__device__ __forceinline__
+int2 getExtRect_fast(const float3& cov, const float& opacity) {
+    // log2(opacity)
+    float l2;
+    asm volatile ("lg2.approx.f32 %0, %1;" : "=f"(l2) : "f"(opacity));
+
+    // power = ln(2) * (8 + log2(opacity))
+    const float ln2   = 0.69314718055f;
+    const float ln2x8 = 5.5451774444f;          // ln2 * 8
+    float power = __fmaf_rn(l2, ln2, ln2x8);
+
+    // sx = cov.x * power, sy = cov.z * power
+    float det = cov.x * cov.z - cov.y * cov.y;
+    if (det <= 0.0f) return {0, 0};
+    float sx = cov.z * power / det;
+    float sy = cov.x * power / det;
+
+    // sqrt.approx
+    float rx, ry;
+    asm volatile ("sqrt.approx.f32 %0, %1;" : "=f"(rx) : "f"(sx));
+    asm volatile ("sqrt.approx.f32 %0, %1;" : "=f"(ry) : "f"(sy));
+
+    // width/height = ceil(sqrt2 * r + 1); use fma + trunc toward zero
+    // const float sqrt2 = 1.41421356f;
+    // int w = __float2int_rz(__fmaf_rn(rx, sqrt2, 1.0f));
+    // int h = __float2int_rz(__fmaf_rn(ry, sqrt2, 1.0f));
+
+    return {rx + 1, ry + 1};
+}
+
+// Perform initial steps for each Gaussian prior to rasterization.
+template<int C>
+__global__ void preprocessCUDA(float2* xy_d,
+    float *depths_d, 
+	int *radii_d,
+	int P, int D, int M,
+	const float* orig_points,
+	const glm::vec3* scales,
+	const float scale_modifier,
+	const glm::vec4* rotations,
+	const float* opacities,
+	const float* dc,
+	const float* shs,
+	bool* clamped,
+	const float* cov3D_precomp,
+	const float* colors_precomp,
+	const float* viewmatrix,
+	const float* projmatrix,
+	const glm::vec3* cam_pos,
+	const int W, int H,
+	const float tan_fovx, float tan_fovy,
+	const float focal_x, float focal_y,
+	int* radii,
+	float2* points_xy_image,
+	float* depths,
+	float* cov3Ds,
+	float* rgb,
+	float4* conic_opacity,
+	const dim3 grid,
+	uint32_t* tiles_touched,
+	bool prefiltered)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= P)
+		return;
+
+	// Initialize radius and touched tiles to 0. If this isn't changed,
+	// this Gaussian will not be processed further.
+	radii[idx] = 0;
+	tiles_touched[idx] = 0;
+
+	// Perform near culling, quit if outside.
+	float3 p_view;
+	if (!in_frustum(idx, orig_points, viewmatrix, projmatrix, prefiltered, p_view))
+		return;
+
+	// Transform point by projecting
+	float3 p_orig = { orig_points[3 * idx], orig_points[3 * idx + 1], orig_points[3 * idx + 2] };
+	float4 p_hom = transformPoint4x4(p_orig, projmatrix);
+	float p_w = 1.0f / (p_hom.w + 0.0000001f);
+	float3 p_proj = { p_hom.x * p_w, p_hom.y * p_w, p_hom.z * p_w };
+
+	// If 3D covariance matrix is precomputed, use it, otherwise compute
+	// from scaling and rotation parameters. 
+	const float* cov3D;
+	if (cov3D_precomp != nullptr)
+	{
+		cov3D = cov3D_precomp + idx * 6;
+	}
+	else
+	{
+		computeCov3D(scales[idx], scale_modifier, rotations[idx], cov3Ds + idx * 6);
+		cov3D = cov3Ds + idx * 6;
+	}
+
+	// Compute 2D screen-space covariance matrix
+	float3 cov = computeCov2D(p_orig, focal_x, focal_y, tan_fovx, tan_fovy, cov3D, viewmatrix);
+
+	// Invert covariance (EWA algorithm)
+	float det = (cov.x * cov.z - cov.y * cov.y);
+	if (det == 0.0f)
+		return;
+	float det_inv = 1.f / det;
+	float3 conic = { cov.z * det_inv, -cov.y * det_inv, cov.x * det_inv };
+
+	// Compute extent in screen space (by finding eigenvalues of
+	// 2D covariance matrix). Use extent to compute a bounding rectangle
+	// of screen-space tiles that this Gaussian overlaps with. Quit if
+	// rectangle covers 0 tiles. 
+	float mid = 0.5f * (cov.x + cov.z);
+	float lambda1 = mid + sqrt(max(0.1f, mid * mid - det));
+	float lambda2 = mid - sqrt(max(0.1f, mid * mid - det));
+	float my_radius = ceil(3.f * sqrt(max(lambda1, lambda2)));
+	float2 point_image = { ndc2Pix(p_proj.x, W), ndc2Pix(p_proj.y, H) };
+	uint2 rect_min, rect_max;
+	// getRect(point_image, my_radius, rect_min, rect_max, grid);
+	getRect(point_image, getExtRect_fast(conic, opacities[idx]), rect_min, rect_max, grid);
+	if ((rect_max.x - rect_min.x) * (rect_max.y - rect_min.y) == 0)
+		return;
+
+	// If colors have been precomputed, use them, otherwise convert
+	// spherical harmonics coefficients to RGB color.
+	if (colors_precomp == nullptr)
+	{
+		glm::vec3 result = computeColorFromSH(idx, D, M, (glm::vec3*)orig_points, *cam_pos, dc, shs, clamped);
+		rgb[idx * C + 0] = result.x;
+		rgb[idx * C + 1] = result.y;
+		rgb[idx * C + 2] = result.z;
+	}
+
+	// Store some useful helper data for the next steps.
+	depths[idx] = p_view.z;
+	radii[idx] = my_radius;
+	points_xy_image[idx] = point_image;
+
+	depths_d[idx] = p_view.z;
+	xy_d[idx] = { point_image.x, point_image.y };
+	radii_d[idx] = my_radius;
+
+	// Inverse 2D covariance and opacity neatly pack into one float4
+	conic_opacity[idx] = { conic.x, conic.y, conic.z, opacities[idx] };
+	tiles_touched[idx] = (rect_max.y - rect_min.y) * (rect_max.x - rect_min.x);
+}
+
+// Main rasterization method. Collaboratively works on one tile per
+// block, each thread treats one pixel. Alternates between fetching 
+// and rasterizing data.
+template <uint32_t CHANNELS>
+__global__ void __launch_bounds__(BLOCK_X * BLOCK_Y)
+renderCUDA(
+	const uint2* __restrict__ ranges,
+	const uint32_t* __restrict__ point_list,
+	const uint32_t* __restrict__ per_tile_bucket_offset, uint32_t* __restrict__ bucket_to_tile,
+	float* __restrict__ sampled_T, float* __restrict__ sampled_ar,
+	int W, int H,
+	const float2* __restrict__ points_xy_image,
+	const float* __restrict__ features,
+	const float4* __restrict__ conic_opacity,
+	float* __restrict__ final_T,
+	uint32_t* __restrict__ n_contrib,
+	uint32_t* __restrict__ max_contrib,
+	float* __restrict__ pixel_colors,
+	const float* __restrict__ bg_color,
+	float* __restrict__ out_color,
+	int* __restrict__ count_contrib,
+	float* __restrict__ pixel_weights,
+	float* __restrict__ accum_weights,
+	int* __restrict__ reverse_count,
+	float* __restrict__ blend_weights,
+	float* __restrict__ dist_accum)
+{
+	// Identify current tile and associated min/max pixel range.
+	auto block = cg::this_thread_block();
+	uint32_t horizontal_blocks = (W + BLOCK_X - 1) / BLOCK_X;
+	uint2 pix_min = { block.group_index().x * BLOCK_X, block.group_index().y * BLOCK_Y };
+	uint2 pix_max = { min(pix_min.x + BLOCK_X, W), min(pix_min.y + BLOCK_Y , H) };
+	uint2 pix = { pix_min.x + block.thread_index().x, pix_min.y + block.thread_index().y };
+	uint32_t pix_id = W * pix.y + pix.x;
+	float2 pixf = { (float)pix.x, (float)pix.y };
+
+	// Check if this thread is associated with a valid pixel or outside.
+	bool inside = pix.x < W&& pix.y < H;
+	// Done threads can help with fetching, but don't rasterize
+	bool done = !inside;
+
+	// Load start/end range of IDs to process in bit sorted list.
+	uint32_t tile_id = block.group_index().y * horizontal_blocks + block.group_index().x;
+	uint2 range = ranges[tile_id];
+	const int rounds = ((range.y - range.x + BLOCK_SIZE - 1) / BLOCK_SIZE);
+	int toDo = range.y - range.x;
+
+	// what is the number of buckets before me? what is my offset?
+	uint32_t bbm = tile_id == 0 ? 0 : per_tile_bucket_offset[tile_id - 1];
+	// let's first quickly also write the bucket-to-tile mapping
+	int num_buckets = (toDo + 31) / 32;
+	for (int i = 0; i < (num_buckets + BLOCK_SIZE - 1) / BLOCK_SIZE; ++i) {
+		int bucket_idx = i * BLOCK_SIZE + block.thread_rank();
+		if (bucket_idx < num_buckets) {
+			bucket_to_tile[bbm + bucket_idx] = tile_id;
+		}
+	}
+	
+	// Allocate storage for batches of collectively fetched data.
+	__shared__ int collected_id[BLOCK_SIZE];
+	__shared__ float2 collected_xy[BLOCK_SIZE];
+	__shared__ float4 collected_conic_opacity[BLOCK_SIZE];
+
+	// Initialize helper variables
+	float T = 1.0f;
+	uint32_t contributor = 0;
+	uint32_t last_contributor = 0;
+	float C[CHANNELS] = { 0 };
+
+	int contribs = 0;
+	// Iterate over batches until all done or range is complete
+	for (int i = 0; i < rounds; i++, toDo -= BLOCK_SIZE)
+	{
+		// End if entire block votes that it is done rasterizing
+		int num_done = __syncthreads_count(done);
+		if (num_done == BLOCK_SIZE)
+			break;
+
+		// Collectively fetch per-Gaussian data from global to shared
+		int progress = i * BLOCK_SIZE + block.thread_rank();
+		if (range.x + progress < range.y)
+		{
+			int coll_id = point_list[range.x + progress];
+			collected_id[block.thread_rank()] = coll_id;
+			collected_xy[block.thread_rank()] = points_xy_image[coll_id];
+			collected_conic_opacity[block.thread_rank()] = conic_opacity[coll_id];
+		}
+		block.sync();
+
+		// Iterate over current batch
+		for (int j = 0; !done && j < min(BLOCK_SIZE, toDo); j++)
+		{
+			// add incoming T value for every 32nd gaussian
+			if (j % 32 == 0) {
+				sampled_T[(bbm * BLOCK_SIZE) + block.thread_rank()] = T;
+				for (int ch = 0; ch < CHANNELS; ++ch) {
+					sampled_ar[(bbm * BLOCK_SIZE * CHANNELS) + ch * BLOCK_SIZE + block.thread_rank()] = C[ch];
+				}
+				++bbm;
+			}
+
+			// Keep track of current position in range
+			contributor++;
+
+			// Resample using conic matrix (cf. "Surface 
+			// Splatting" by Zwicker et al., 2001)
+			float2 xy = collected_xy[j];
+			float2 d = { xy.x - pixf.x, xy.y - pixf.y };
+			float4 con_o = collected_conic_opacity[j];
+			float power = -0.5f * (con_o.x * d.x * d.x + con_o.z * d.y * d.y) - con_o.y * d.x * d.y;
+			if (power > 0.0f)
+				continue;
+
+			// Eq. (2) from 3D Gaussian splatting paper.
+			// Obtain alpha by multiplying with Gaussian opacity
+			// and its exponential falloff from mean.
+			// Avoid numerical instabilities (see paper appendix). 
+			float alpha = min(0.99f, con_o.w * exp(power));
+			if (alpha < 1.0f / 255.0f)
+				continue;
+			float test_T = T * (1 - alpha);
+			if (test_T < 0.0001f)
+			{
+				done = true;
+				continue;
+			}
+
+			// Eq. (3) from 3D Gaussian splatting paper.
+			for (int ch = 0; ch < CHANNELS; ch++)
+				C[ch] += features[collected_id[j] * CHANNELS + ch] * alpha * T;
+
+			if(pixel_weights != nullptr)
+			{
+				atomicAdd(&accum_weights[collected_id[j]], pixel_weights[pix_id]);
+				atomicAdd(&reverse_count[collected_id[j]], 1);
+				atomicAdd(&blend_weights[collected_id[j]], T * alpha);
+				atomicAdd(&dist_accum[collected_id[j]], sqrt(d.x*d.x + d.y*d.y));
+			}
+
+			T = test_T;
+
+			// Keep track of last range entry to update this
+			// pixel.
+			last_contributor = contributor;
+			contribs++;
+		}
+	}
+
+	// All threads that treat valid pixel write out their final
+	// rendering data to the frame and auxiliary buffers.
+	if (inside)
+	{
+		final_T[pix_id] = T;
+		n_contrib[pix_id] = last_contributor;
+		for (int ch = 0; ch < CHANNELS; ch++)
+		{
+			pixel_colors[ch * H * W + pix_id] = C[ch];
+			out_color[ch * H * W + pix_id] = C[ch] + T * bg_color[ch];
+		}
+
+		if(count_contrib)
+			count_contrib[pix_id] = contribs;
+	}
+
+	// max reduce the last contributor
+    typedef cub::BlockReduce<uint32_t, BLOCK_X, cub::BLOCK_REDUCE_WARP_REDUCTIONS, BLOCK_Y> BlockReduce;
+    __shared__ typename BlockReduce::TempStorage temp_storage;
+    last_contributor = BlockReduce(temp_storage).Reduce(last_contributor, cub::Max());
+	if (block.thread_rank() == 0) {
+		max_contrib[tile_id] = last_contributor;
+	}
+}
+
+
+void FORWARD::render(
+	const dim3 grid, dim3 block,
+	const uint2* ranges,
+	const uint32_t* point_list,
+	const uint32_t* per_tile_bucket_offset, uint32_t* bucket_to_tile,
+	float* sampled_T, float* sampled_ar,
+	int W, int H,
+	const float2* means2D,
+	const float* colors,
+	const float4* conic_opacity,
+	float* final_T,
+	uint32_t* n_contrib,
+	uint32_t* max_contrib,
+	float* pixel_colors,
+	const float* bg_color,
+	float* out_color,
+	int* img_contrib_counts,
+	int* img_contrib_offsets,
+	char* img_contrib_scan,
+	size_t scan_size,
+	std::function<int* (size_t)> listBuffer,
+	std::function<float* (size_t)> listBufferRender,
+	std::function<float* (size_t)> listBufferDistance,
+	float* pixel_weights,
+	float* accum_weights,
+	int* reverse_count,
+	float* blend_weights,
+	float* dist_accum)
+{
+	renderCUDA<NUM_CHAFFELS> << <grid, block >> > (
+		ranges,
+		point_list,
+		per_tile_bucket_offset, bucket_to_tile,
+		sampled_T, sampled_ar,
+		W, H,
+		means2D,
+		colors,
+		conic_opacity,
+		final_T,
+		n_contrib,
+		max_contrib,
+		pixel_colors,
+		bg_color,
+		out_color,
+		img_contrib_counts,
+		pixel_weights,
+		accum_weights,
+		reverse_count,
+		blend_weights,
+		dist_accum
+		);
+}
+
+void FORWARD::preprocess(float2* xy_d,
+    float *depths_d,
+	int *radii_d,
+	int P, int D, int M,
+	const float* means3D,
+	const glm::vec3* scales,
+	const float scale_modifier,
+	const glm::vec4* rotations,
+	const float* opacities,
+	const float* dc,
+	const float* shs,
+	bool* clamped,
+	const float* cov3D_precomp,
+	const float* colors_precomp,
+	const float* viewmatrix,
+	const float* projmatrix,
+	const glm::vec3* cam_pos,
+	const int W, int H,
+	const float focal_x, float focal_y,
+	const float tan_fovx, float tan_fovy,
+	int* radii,
+	float2* means2D,
+	float* depths,
+	float* cov3Ds,
+	float* rgb,
+	float4* conic_opacity,
+	const dim3 grid,
+	uint32_t* tiles_touched,
+	bool prefiltered)
+{
+	preprocessCUDA<NUM_CHAFFELS> << <(P + 255) / 256, 256 >> > (
+		xy_d,
+		depths_d,
+		radii_d,
+		P, D, M,
+		means3D,
+		scales,
+		scale_modifier,
+		rotations,
+		opacities,
+		dc,
+		shs,
+		clamped,
+		cov3D_precomp,
+		colors_precomp,
+		viewmatrix, 
+		projmatrix,
+		cam_pos,
+		W, H,
+		tan_fovx, tan_fovy,
+		focal_x, focal_y,
+		radii,
+		means2D,
+		depths,
+		cov3Ds,
+		rgb,
+		conic_opacity,
+		grid,
+		tiles_touched,
+		prefiltered);
+}

--- a/taminggs/forward.h
+++ b/taminggs/forward.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#ifndef CUDA_RASTERIZER_FORWARD_H_INCLUDED
+#define CUDA_RASTERIZER_FORWARD_H_INCLUDED
+
+#include <cuda.h>
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+#define GLM_FORCE_CUDA
+#include <glm/glm.hpp>
+#include <functional>
+
+namespace FORWARD
+{
+	// Perform initial steps for each Gaussian prior to rasterization.
+	void preprocess(float2* xy_d,
+    	float *depths_d,
+		int *radii_d,
+		int P, int D, int M,
+		const float* orig_points,
+		const glm::vec3* scales,
+		const float scale_modifier,
+		const glm::vec4* rotations,
+		const float* opacities,
+		const float* dc,
+		const float* shs,
+		bool* clamped,
+		const float* cov3D_precomp,
+		const float* colors_precomp,
+		const float* viewmatrix,
+		const float* projmatrix,
+		const glm::vec3* cam_pos,
+		const int W, int H,
+		const float focal_x, float focal_y,
+		const float tan_fovx, float tan_fovy,
+		int* radii,
+		float2* points_xy_image,
+		float* depths,
+		float* cov3Ds,
+		float* colors,
+		float4* conic_opacity,
+		const dim3 grid,
+		uint32_t* tiles_touched,
+		bool prefiltered);
+
+	// Main rasterization method.
+	void render(
+		const dim3 grid, dim3 block,
+		const uint2* ranges,
+		const uint32_t* point_list,
+		const uint32_t* per_tile_bucket_offset, uint32_t* bucket_to_tile,
+		float* sampled_T, float* sampled_ar,
+		int W, int H,
+		const float2* points_xy_image,
+		const float* features,
+		const float4* conic_opacity,
+		float* final_T,
+		uint32_t* n_contrib,
+		uint32_t* max_contrib,
+		float* pixel_colors,
+		const float* bg_color,
+		float* out_color,
+		int* img_contribs,
+		int* img_contrib_offsets,
+		char* img_contrib_scan,
+		size_t scan_size,
+		std::function<int* (size_t)> listBuffer,
+		std::function<float* (size_t)> listBufferRender,
+		std::function<float* (size_t)> listBufferDistance,
+		float* pixel_weights,
+		float* accum_weights,
+		int* reverse_count,
+		float* blend_weights,
+		float* dist_accum);
+}
+
+
+#endif

--- a/taminggs/rasterize_points.cu
+++ b/taminggs/rasterize_points.cu
@@ -1,0 +1,340 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#include <math.h>
+#include <torch/extension.h>
+#include <cstdio>
+#include <sstream>
+#include <iostream>
+#include <tuple>
+#include <stdio.h>
+#include <cuda_runtime_api.h>
+#include <memory>
+#include <fstream>
+#include <string>
+#include <functional>
+
+#include "config.h"
+#include "rasterizer.h"
+#include "adam.h"
+#include "rasterize_points.h"
+
+namespace taminggs {
+
+    std::function<char*(size_t N)> resizeFunctional(torch::Tensor& t) {
+        auto lambda = [&t](size_t N) {
+            t.resize_({(long long)N});
+            return reinterpret_cast<char*>(t.contiguous().data_ptr());
+        };
+        return lambda;
+    }
+
+    std::function<int*(size_t N)> resizeIntFunctional(torch::Tensor& t) {
+        auto lambda = [&t](size_t N) {
+            t.resize_({(long long)N});
+            return t.contiguous().data_ptr<int>();
+        };
+        return lambda;
+    }
+
+    std::function<float*(size_t N)> resizeFloatFunctional(torch::Tensor& t) {
+        auto lambda = [&t](size_t N) {
+            t.resize_({(long long)N});
+            return t.contiguous().data_ptr<float>();
+        };
+        return lambda;
+    }
+
+    std::tuple<int, int, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+    RasterizeGaussiansCUDA(
+        const torch::Tensor& background,
+        const torch::Tensor& means3D,
+        const torch::Tensor& colors,
+        const torch::Tensor& opacity,
+        const torch::Tensor& scales,
+        const torch::Tensor& rotations,
+        const float scale_modifier,
+        const torch::Tensor& cov3D_precomp,
+        const torch::Tensor& viewmatrix,
+        const torch::Tensor& projmatrix,
+        const float tan_fovx, 
+        const float tan_fovy,
+        const int image_height,
+        const int image_width,
+        const torch::Tensor& dc,
+        const torch::Tensor& sh,
+        const int degree,
+        const torch::Tensor& campos,
+        const bool prefiltered,
+        const bool debug,
+        const torch::Tensor& pixel_weights)
+    {
+    if (means3D.ndimension() != 2 || means3D.size(1) != 3) {
+        AT_ERROR("means3D must have dimensions (num_points, 3)");
+    }
+    
+    const int P = means3D.size(0);
+    const int H = image_height;
+    const int W = image_width;
+
+    auto int_opts = means3D.options().dtype(torch::kInt32);
+    auto float_opts = means3D.options().dtype(torch::kFloat32);
+
+    torch::Tensor out_color = torch::full({NUM_CHAFFELS, H, W}, 0.0, float_opts);
+    torch::Tensor radii = torch::full({P}, 0, means3D.options().dtype(torch::kInt32));
+    
+    torch::Device device(torch::kCUDA);
+    torch::TensorOptions options(torch::kByte);
+    torch::Tensor geomBuffer = torch::empty({0}, options.device(device));
+    torch::Tensor binningBuffer = torch::empty({0}, options.device(device));
+    torch::Tensor imgBuffer = torch::empty({0}, options.device(device));
+    torch::Tensor sampleBuffer = torch::empty({0}, options.device(device));
+    std::function<char*(size_t)> geomFunc = resizeFunctional(geomBuffer);
+    std::function<char*(size_t)> binningFunc = resizeFunctional(binningBuffer);
+    std::function<char*(size_t)> imgFunc = resizeFunctional(imgBuffer);
+    std::function<char*(size_t)> sampleFunc = resizeFunctional(sampleBuffer);
+    
+    torch::Tensor xy_d = torch::zeros({P, 2}, means3D.options().dtype(torch::kFloat32));
+    torch::Tensor depths_d = torch::zeros({P}, means3D.options().dtype(torch::kFloat32));
+    torch::Tensor radii_d = torch::zeros({P}, means3D.options().dtype(torch::kInt32));
+
+    torch::Tensor countBuffer = torch::empty({0}, int_opts);
+    torch::Tensor offsetBuffer = torch::empty({0}, int_opts);
+    torch::Tensor listBuffer = torch::empty({0}, int_opts);
+    torch::Tensor listBufferRender = torch::empty({0}, float_opts);
+    torch::Tensor listBufferDistance = torch::empty({0}, float_opts);
+    std::function<int*(size_t)> listFunc = resizeIntFunctional(listBuffer);
+    std::function<float*(size_t)> listFuncRender = resizeFloatFunctional(listBufferRender);
+    std::function<float*(size_t)> listFuncDistance = resizeFloatFunctional(listBufferDistance);
+
+    float* weight_ptr = nullptr;
+    float* accum_weight_ptr = nullptr;
+    int* reverse_count_ptr = nullptr;
+    float* blending_weight_ptr = nullptr;
+    float* dist_accum_ptr = nullptr;
+
+    torch::Tensor accumWeightsBuffer = torch::empty({0}, float_opts);
+    torch::Tensor reverseCount = torch::empty({0}, int_opts);
+    torch::Tensor blendingWeights = torch::empty({0}, float_opts);
+    torch::Tensor distAccum = torch::empty({0}, float_opts);
+    if(pixel_weights.size(0) != 0)
+    {
+        countBuffer = torch::full({H, W}, 0, int_opts);
+        offsetBuffer = torch::full({H, W}, 0, int_opts);
+
+        if(pixel_weights.size(0) > 1)
+        {
+            weight_ptr = pixel_weights.contiguous().data<float>();
+            accumWeightsBuffer = torch::full({P}, 0, float_opts);
+            accum_weight_ptr = accumWeightsBuffer.contiguous().data<float>();
+
+            reverseCount = torch::full({P}, 0, int_opts);
+            reverse_count_ptr = reverseCount.contiguous().data<int>();
+            blendingWeights = torch::full({P}, 0, float_opts);
+            blending_weight_ptr = blendingWeights.contiguous().data<float>();
+            distAccum = torch::full({P}, 0, float_opts);
+            dist_accum_ptr = distAccum.contiguous().data<float>();
+        }
+    }
+    
+    int rendered = 0;
+    int num_buckets = 0;
+    if(P != 0)
+    {
+        int M = 0;
+        if(sh.size(0) != 0)
+        {
+            M = sh.size(1);
+        }
+
+        auto tup = CudaRasterizer::Rasterizer::forward(
+            (float2 *)xy_d.contiguous().data_ptr<float>(),
+            depths_d.contiguous().data_ptr<float>(),
+            radii_d.contiguous().data_ptr<int>(),
+            geomFunc,
+            binningFunc,
+            imgFunc,
+            sampleFunc,
+            listFunc,
+            listFuncRender,
+            listFuncDistance,
+            countBuffer.contiguous().data_ptr<int>(),
+            offsetBuffer.contiguous().data_ptr<int>(),
+            P, degree, M,
+            background.contiguous().data<float>(),
+            W, H,
+            means3D.contiguous().data<float>(),
+            dc.contiguous().data_ptr<float>(),
+            sh.contiguous().data_ptr<float>(),
+            colors.contiguous().data<float>(), 
+            opacity.contiguous().data<float>(), 
+            scales.contiguous().data_ptr<float>(),
+            scale_modifier,
+            rotations.contiguous().data_ptr<float>(),
+            cov3D_precomp.contiguous().data<float>(), 
+            viewmatrix.contiguous().data<float>(), 
+            projmatrix.contiguous().data<float>(),
+            campos.contiguous().data<float>(),
+            tan_fovx,
+            tan_fovy,
+            prefiltered,
+            out_color.contiguous().data<float>(),
+            radii.contiguous().data<int>(),
+            debug,
+            weight_ptr,
+            accum_weight_ptr,
+            reverse_count_ptr,
+            blending_weight_ptr,
+            dist_accum_ptr);
+
+            rendered = std::get<0>(tup);
+            num_buckets = std::get<1>(tup);
+    }
+    return std::make_tuple(rendered, num_buckets, out_color, radii, geomBuffer, binningBuffer, imgBuffer, sampleBuffer, offsetBuffer, listBuffer, listBufferRender, listBufferDistance, xy_d, depths_d, radii_d, accumWeightsBuffer, reverseCount, blendingWeights, distAccum);
+    }
+
+    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+    RasterizeGaussiansBackwardCUDA(
+        const torch::Tensor& background,
+        const torch::Tensor& means3D,
+        const torch::Tensor& radii,
+        const torch::Tensor& colors,
+        const torch::Tensor& scales,
+        const torch::Tensor& rotations,
+        const float scale_modifier,
+        const torch::Tensor& cov3D_precomp,
+        const torch::Tensor& viewmatrix,
+        const torch::Tensor& projmatrix,
+        const float tan_fovx,
+        const float tan_fovy,
+        const torch::Tensor& dL_dout_color,
+        const torch::Tensor& dc,
+        const torch::Tensor& sh,
+        const int degree,
+        const torch::Tensor& campos,
+        const torch::Tensor& geomBuffer,
+        const int R,
+        const torch::Tensor& binningBuffer,
+        const torch::Tensor& imageBuffer,
+        const int B,
+        const torch::Tensor& sampleBuffer,
+        const bool debug) 
+    {
+    const int P = means3D.size(0);
+    const int H = dL_dout_color.size(1);
+    const int W = dL_dout_color.size(2);
+    
+    int M = 0;
+    if(sh.size(0) != 0)
+    {	
+        M = sh.size(1);
+    }
+
+    torch::Tensor dL_dmeans3D = torch::zeros({P, 3}, means3D.options());
+    torch::Tensor dL_dmeans2D = torch::zeros({P, 3}, means3D.options());
+    torch::Tensor dL_dcolors = torch::zeros({P, NUM_CHAFFELS}, means3D.options());
+    torch::Tensor dL_dconic = torch::zeros({P, 2, 2}, means3D.options());
+    torch::Tensor dL_dopacity = torch::zeros({P, 1}, means3D.options());
+    torch::Tensor dL_dcov3D = torch::zeros({P, 6}, means3D.options());
+    torch::Tensor dL_ddc = torch::zeros({P, 1, 3}, means3D.options());
+    torch::Tensor dL_dsh = torch::zeros({P, M, 3}, means3D.options());
+    torch::Tensor dL_dscales = torch::zeros({P, 3}, means3D.options());
+    torch::Tensor dL_drotations = torch::zeros({P, 4}, means3D.options());
+    
+    if(P != 0)
+    {  
+        CudaRasterizer::Rasterizer::backward(P, degree, M, R, B,
+        background.contiguous().data<float>(),
+        W, H, 
+        means3D.contiguous().data<float>(),
+        dc.contiguous().data<float>(),
+        sh.contiguous().data<float>(),
+        colors.contiguous().data<float>(),
+        scales.data_ptr<float>(),
+        scale_modifier,
+        rotations.data_ptr<float>(),
+        cov3D_precomp.contiguous().data<float>(),
+        viewmatrix.contiguous().data<float>(),
+        projmatrix.contiguous().data<float>(),
+        campos.contiguous().data<float>(),
+        tan_fovx,
+        tan_fovy,
+        radii.contiguous().data<int>(),
+        reinterpret_cast<char*>(geomBuffer.contiguous().data_ptr()),
+        reinterpret_cast<char*>(binningBuffer.contiguous().data_ptr()),
+        reinterpret_cast<char*>(imageBuffer.contiguous().data_ptr()),
+        reinterpret_cast<char*>(sampleBuffer.contiguous().data_ptr()),
+        dL_dout_color.contiguous().data<float>(),
+        dL_dmeans2D.contiguous().data<float>(),
+        dL_dconic.contiguous().data<float>(),  
+        dL_dopacity.contiguous().data<float>(),
+        dL_dcolors.contiguous().data<float>(),
+        dL_dmeans3D.contiguous().data<float>(),
+        dL_dcov3D.contiguous().data<float>(),
+        dL_ddc.contiguous().data<float>(),
+        dL_dsh.contiguous().data<float>(),
+        dL_dscales.contiguous().data<float>(),
+        dL_drotations.contiguous().data<float>(),
+        debug);
+    }
+
+    return std::make_tuple(dL_dmeans2D, dL_dcolors, dL_dopacity, dL_dmeans3D, dL_dcov3D, dL_ddc, dL_dsh, dL_dscales, dL_drotations);
+    }
+
+    torch::Tensor markVisible(
+            torch::Tensor& means3D,
+            torch::Tensor& viewmatrix,
+            torch::Tensor& projmatrix)
+    { 
+    const int P = means3D.size(0);
+    
+    torch::Tensor present = torch::full({P}, false, means3D.options().dtype(at::kBool));
+    
+    if(P != 0)
+    {
+        CudaRasterizer::Rasterizer::markVisible(P,
+            means3D.contiguous().data<float>(),
+            viewmatrix.contiguous().data<float>(),
+            projmatrix.contiguous().data<float>(),
+            present.contiguous().data<bool>());
+    }
+    
+    return present;
+    }
+
+    void adamUpdate(
+        torch::Tensor &param,
+        torch::Tensor &param_grad,
+        torch::Tensor &exp_avg,
+        torch::Tensor &exp_avg_sq,
+        torch::Tensor &visible,
+        const float lr,
+        const float b1,
+        const float b2,
+        const float eps,
+        const uint32_t N,
+        const uint32_t M
+    ){
+        ADAM::adamUpdate(
+            param.contiguous().data<float>(),
+            param_grad.contiguous().data<float>(),
+            exp_avg.contiguous().data<float>(),
+            exp_avg_sq.contiguous().data<float>(),
+            visible.contiguous().data<bool>(),
+            lr,
+            b1,
+            b2,
+            eps,
+            N,
+            M);
+    }
+
+}

--- a/taminggs/rasterize_points.h
+++ b/taminggs/rasterize_points.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#pragma once
+#include <torch/extension.h>
+#include <cstdio>
+#include <tuple>
+#include <string>
+
+namespace taminggs {
+	
+    std::tuple<int, int, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+    RasterizeGaussiansCUDA(
+        const torch::Tensor& background,
+        const torch::Tensor& means3D,
+        const torch::Tensor& colors,
+        const torch::Tensor& opacity,
+        const torch::Tensor& scales,
+        const torch::Tensor& rotations,
+        const float scale_modifier,
+        const torch::Tensor& cov3D_precomp,
+        const torch::Tensor& viewmatrix,
+        const torch::Tensor& projmatrix,
+        const float tan_fovx, 
+        const float tan_fovy,
+        const int image_height,
+        const int image_width,
+        const torch::Tensor& dc,
+        const torch::Tensor& sh,
+        const int degree,
+        const torch::Tensor& campos,
+        const bool prefiltered,
+        const bool debug,
+        const torch::Tensor& pixel_weights);
+
+    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+    RasterizeGaussiansBackwardCUDA(
+        const torch::Tensor& background,
+        const torch::Tensor& means3D,
+        const torch::Tensor& radii,
+        const torch::Tensor& colors,
+        const torch::Tensor& scales,
+        const torch::Tensor& rotations,
+        const float scale_modifier,
+        const torch::Tensor& cov3D_precomp,
+        const torch::Tensor& viewmatrix,
+        const torch::Tensor& projmatrix,
+        const float tan_fovx, 
+        const float tan_fovy,
+        const torch::Tensor& dL_dout_color,
+        const torch::Tensor& dc,
+        const torch::Tensor& sh,
+        const int degree,
+        const torch::Tensor& campos,
+        const torch::Tensor& geomBuffer,
+        const int R,
+        const torch::Tensor& binningBuffer,
+        const torch::Tensor& imageBuffer,
+        const int B,
+        const torch::Tensor& sampleBuffer,
+        const bool debug);
+            
+    torch::Tensor markVisible(
+            torch::Tensor& means3D,
+            torch::Tensor& viewmatrix,
+            torch::Tensor& projmatrix);
+
+    torch::Tensor conv2DForward(torch::Tensor &input);
+
+    void adamUpdate(
+        torch::Tensor &param,
+        torch::Tensor &param_grad,
+        torch::Tensor &exp_avg,
+        torch::Tensor &exp_avg_sq,
+        torch::Tensor &visible,
+        const float lr,
+        const float b1,
+        const float b2,
+        const float eps,
+        const uint32_t N,
+        const uint32_t M);
+
+}

--- a/taminggs/rasterizer.h
+++ b/taminggs/rasterizer.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#ifndef CUDA_RASTERIZER_H_INCLUDED
+#define CUDA_RASTERIZER_H_INCLUDED
+
+#include <vector>
+#include <functional>
+
+namespace CudaRasterizer
+{
+	class Rasterizer
+	{
+	public:
+
+		static void markVisible(
+			int P,
+			float* means3D,
+			float* viewmatrix,
+			float* projmatrix,
+			bool* present);
+
+		static std::tuple<int,int> forward(
+			float2* xy_d,
+			float *depths_d,
+			int *radii_d,
+			std::function<char* (size_t)> geometryBuffer,
+			std::function<char* (size_t)> binningBuffer,
+			std::function<char* (size_t)> imageBuffer,
+			std::function<char* (size_t)> sampleBuffer,
+			std::function<int* (size_t)> listBuffer,
+			std::function<float* (size_t)> listBufferRender,
+			std::function<float* (size_t)> listBufferDistance,
+			int* contribCountBuffer, int* contribOffsetBuffer,
+			const int P, int D, int M,
+			const float* background,
+			const int width, int height,
+			const float* means3D,
+			const float* dc,
+			const float* shs,
+			const float* colors_precomp,
+			const float* opacities,
+			const float* scales,
+			const float scale_modifier,
+			const float* rotations,
+			const float* cov3D_precomp,
+			const float* viewmatrix,
+			const float* projmatrix,
+			const float* cam_pos,
+			const float tan_fovx, float tan_fovy,
+			const bool prefiltered,
+			float* out_color,
+			int* radii = nullptr,
+			bool debug = false,
+			float* pixel_weights = nullptr,
+			float* accum_weights = nullptr,
+			int* reverse_count = nullptr,
+			float* blend_weights = nullptr,
+			float* dist_accum = nullptr);
+
+		static void backward(
+			const int P, int D, int M, int R, int B,
+			const float* background,
+			const int width, int height,
+			const float* means3D,
+			const float* dc,
+			const float* shs,
+			const float* colors_precomp,
+			const float* scales,
+			const float scale_modifier,
+			const float* rotations,
+			const float* cov3D_precomp,
+			const float* viewmatrix,
+			const float* projmatrix,
+			const float* campos,
+			const float tan_fovx, float tan_fovy,
+			const int* radii,
+			char* geom_buffer,
+			char* binning_buffer,
+			char* image_buffer,
+			char* sample_buffer,
+			const float* dL_dpix,
+			float* dL_dmean2D,
+			float* dL_dconic,
+			float* dL_dopacity,
+			float* dL_dcolor,
+			float* dL_dmean3D,
+			float* dL_dcov3D,
+			float* dL_ddc,
+			float* dL_dsh,
+			float* dL_dscale,
+			float* dL_drot,
+			bool debug);
+	};
+};
+
+#endif

--- a/taminggs/rasterizer_impl.cu
+++ b/taminggs/rasterizer_impl.cu
@@ -1,0 +1,682 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#include "rasterizer_impl.h"
+#include <iostream>
+#include <fstream>
+#include <algorithm>
+#include <numeric>
+#include <cuda.h>
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+#include <cub/cub.cuh>
+#include <cub/device/device_radix_sort.cuh>
+#define GLM_FORCE_CUDA
+#include <glm/glm.hpp>
+
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+namespace cg = cooperative_groups;
+
+#include "auxiliary.h"
+#include "forward.h"
+#include "backward.h"
+
+// Helper function to find the next-highest bit of the MSB
+// on the CPU.
+uint32_t getHigherMsb(uint32_t n)
+{
+	uint32_t msb = sizeof(n) * 4;
+	uint32_t step = msb;
+	while (step > 1)
+	{
+		step /= 2;
+		if (n >> msb)
+			msb += step;
+		else
+			msb -= step;
+	}
+	if (n >> msb)
+		msb++;
+	return msb;
+}
+
+__device__ inline float evaluate_opacity_factor(const float dx, const float dy, const float4 co) {
+	return 0.5f * (co.x * dx * dx + co.z * dy * dy) + co.y * dx * dy;
+}
+
+template<uint32_t PATCH_WIDTH, uint32_t PATCH_HEIGHT>
+__device__ inline float max_contrib_power_rect_gaussian_float(
+	const float4 co, 
+	const float2 mean, 
+	const glm::vec2 rect_min,
+	const glm::vec2 rect_max,
+	glm::vec2& max_pos)
+{
+	const float x_min_diff = rect_min.x - mean.x;
+	const float x_left = x_min_diff > 0.0f;
+	// const float x_left = mean.x < rect_min.x;
+	const float not_in_x_range = x_left + (mean.x > rect_max.x);
+
+	const float y_min_diff = rect_min.y - mean.y;
+	const float y_above =  y_min_diff > 0.0f;
+	// const float y_above = mean.y < rect_min.y;
+	const float not_in_y_range = y_above + (mean.y > rect_max.y);
+
+	max_pos = {mean.x, mean.y};
+	float max_contrib_power = 0.0f;
+
+	if ((not_in_y_range + not_in_x_range) > 0.0f)
+	{
+		const float px = x_left * rect_min.x + (1.0f - x_left) * rect_max.x;
+		const float py = y_above * rect_min.y + (1.0f - y_above) * rect_max.y;
+
+		const float dx = copysign(float(PATCH_WIDTH), x_min_diff);
+		const float dy = copysign(float(PATCH_HEIGHT), y_min_diff);
+
+		const float diffx = mean.x - px;
+		const float diffy = mean.y - py;
+
+		const float rcp_dxdxcox = __frcp_rn(PATCH_WIDTH * PATCH_WIDTH * co.x); // = 1.0 / (dx*dx*co.x)
+		const float rcp_dydycoz = __frcp_rn(PATCH_HEIGHT * PATCH_HEIGHT * co.z); // = 1.0 / (dy*dy*co.z)
+
+		const float tx = not_in_y_range * __saturatef((dx * co.x * diffx + dx * co.y * diffy) * rcp_dxdxcox);
+		const float ty = not_in_x_range * __saturatef((dy * co.y * diffx + dy * co.z * diffy) * rcp_dydycoz);
+		max_pos = {px + tx * dx, py + ty * dy};
+		
+		const float2 max_pos_diff = {mean.x - max_pos.x, mean.y - max_pos.y};
+		max_contrib_power = evaluate_opacity_factor(max_pos_diff.x, max_pos_diff.y, co);
+	}
+
+	return max_contrib_power;
+}
+
+// Wrapper method to call auxiliary coarse frustum containment test.
+// Mark all Gaussians that pass it.
+__global__ void checkFrustum(int P,
+	const float* orig_points,
+	const float* viewmatrix,
+	const float* projmatrix,
+	bool* present)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= P)
+		return;
+
+	float3 p_view;
+	present[idx] = in_frustum(idx, orig_points, viewmatrix, projmatrix, false, p_view);
+}
+
+__device__ __forceinline__
+int2 getExtRect_fast(const float4& cov) {
+    // log2(opacity)
+    float l2;
+    asm volatile ("lg2.approx.f32 %0, %1;" : "=f"(l2) : "f"(cov.w));
+
+    // power = ln(2) * (8 + log2(opacity))
+    const float ln2   = 0.69314718055f;
+    const float ln2x8 = 5.5451774444f;          // ln2 * 8
+    float power = __fmaf_rn(l2, ln2, ln2x8);
+
+    // sx = cov.x * power, sy = cov.z * power
+    float det = cov.x * cov.z - cov.y * cov.y;
+    if (det <= 0.0f) return {0, 0};
+    float sx = cov.z * power / det;
+    float sy = cov.x * power / det;
+
+    // sqrt.approx
+    float rx, ry;
+    asm volatile ("sqrt.approx.f32 %0, %1;" : "=f"(rx) : "f"(sx));
+    asm volatile ("sqrt.approx.f32 %0, %1;" : "=f"(ry) : "f"(sy));
+
+    // width/height = ceil(sqrt2 * r + 1); use fma + trunc toward zero
+    // const float sqrt2 = 1.41421356f;
+    // int w = __float2int_rz(__fmaf_rn(rx, sqrt2, 1.0f));
+    // int h = __float2int_rz(__fmaf_rn(ry, sqrt2, 1.0f));
+
+    return {rx + 1, ry + 1};
+}
+
+// Generates one key/value pair for all Gaussian / tile overlaps. 
+// Run once per Gaussian (1:N mapping).
+__global__ void duplicateWithKeys(
+	int P,
+	const float2* points_xy,
+	const float4* __restrict__ conic_opacity,
+	const float* depths,
+	const uint32_t* offsets,
+	uint64_t* gaussian_keys_unsorted,
+	uint32_t* gaussian_values_unsorted,
+	int* radii,
+	dim3 grid,
+	int2* rects)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= P)
+		return;
+
+	// Generate no key/value pair for invisible Gaussians
+	if (radii[idx] > 0)
+	{
+		// Find this Gaussian's offset in buffer for writing keys/values.
+		uint32_t off = (idx == 0) ? 0 : offsets[idx - 1];
+		const uint32_t offset_to = offsets[idx];
+		uint2 rect_min, rect_max;
+
+		// if(rects == nullptr)
+			// getRect(points_xy[idx], radii[idx], rect_min, rect_max, grid);
+		// else
+			// getRect(points_xy[idx], rects[idx], rect_min, rect_max, grid);
+
+		const float4 co = conic_opacity[idx];
+		getRect(points_xy[idx], getExtRect_fast(co), rect_min, rect_max, grid);
+
+		const float2 xy = points_xy[idx];
+		// const float4 co = conic_opacity[idx];
+		const float opacity_threshold = 1.0f / 255.0f;
+		const float opacity_factor_threshold = logf(co.w / opacity_threshold);
+
+		// For each tile that the bounding rect overlaps, emit a 
+		// key/value pair. The key is |  tile ID  |      depth      |,
+		// and the value is the ID of the Gaussian. Sorting the values 
+		// with this key yields Gaussian IDs in a list, such that they
+		// are first sorted by tile and then by depth. 
+		for (int y = rect_min.y; y < rect_max.y; y++)
+		{
+			for (int x = rect_min.x; x < rect_max.x; x++)
+			{
+				const glm::vec2 tile_min(x * BLOCK_X, y * BLOCK_Y);
+				const glm::vec2 tile_max((x + 1) * BLOCK_X - 1, (y + 1) * BLOCK_Y - 1);
+
+				glm::vec2 max_pos;
+				float max_opac_factor = 0.0f;
+				max_opac_factor = max_contrib_power_rect_gaussian_float<BLOCK_X-1, BLOCK_Y-1>(co, xy, tile_min, tile_max, max_pos);
+				
+				uint64_t key = y * grid.x + x;
+				key <<= 32;
+				key |= *((uint32_t*)&depths[idx]);
+				if (max_opac_factor <= opacity_factor_threshold) {
+				gaussian_keys_unsorted[off] = key;
+				gaussian_values_unsorted[off] = idx;
+				off++;
+			}
+		}
+	}
+
+		for (; off < offset_to; ++off) {
+			uint64_t key = (uint32_t) -1;
+			key <<= 32;
+			const float depth = FLT_MAX;
+			key |= *((uint32_t*)&depth);
+			gaussian_values_unsorted[off] = static_cast<uint32_t>(-1);
+			gaussian_keys_unsorted[off] = key;
+		}
+	}
+}
+
+// extern "C" __global__
+// void identifyTileRanges(
+// 	int L,
+// 	const uint64_t* __restrict__ point_list_keys,
+//     uint2* __restrict__ ranges,
+//     uint32_t   invalid = 0xFFFFFFFFF
+// ) {
+
+//     int idx = blockIdx.x * blockDim.x + threadIdx.x;
+//     if (idx >= L) return;
+
+//     uint32_t curr = point_list_keys[idx] >> 32;
+//     bool curr_valid = (curr != invalid);
+
+//     if (idx == 0) {
+//         if (curr_valid) ranges[curr].x = 0;
+//     } else {
+//         uint32_t prev = point_list_keys[idx-1] >> 32;
+//         if (curr != prev) {
+//             if (prev != invalid) ranges[prev].y = idx;
+//             if (curr_valid) ranges[curr].x = idx;
+//         }
+//     }
+
+//     if (idx == L-1 && curr_valid) ranges[curr].y = L;
+
+// }
+
+__global__ void identifyTileRanges(int L, uint64_t* point_list_keys, uint2* ranges)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= L)
+		return;
+
+	// Read tile ID from key. Update start/end of tile range if at limit.
+	uint64_t key = point_list_keys[idx];
+	uint32_t currtile = key >> 32;
+	bool valid_tile = currtile != (uint32_t) -1;
+
+	if (idx == 0)
+		ranges[currtile].x = 0;
+	else
+	{
+		uint32_t prevtile = point_list_keys[idx - 1] >> 32;
+		if (currtile != prevtile)
+		{
+			ranges[prevtile].y = idx;
+			if (valid_tile) 
+			ranges[currtile].x = idx;
+		}
+	}
+	if (idx == L - 1 && valid_tile)
+		ranges[currtile].y = L;
+}
+
+
+// for each tile, see how many buckets/warps are needed to store the state
+__global__ void perTileBucketCount(int T, uint2* ranges, uint32_t* bucketCount) {
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= T)
+		return;
+	
+	uint2 range = ranges[idx];
+	int num_splats = range.y - range.x;
+	int num_buckets = (num_splats + 31) / 32;
+	bucketCount[idx] = (uint32_t) num_buckets;
+}
+
+// Mark Gaussians as visible/invisible, based on view frustum testing
+void CudaRasterizer::Rasterizer::markVisible(
+	int P,
+	float* means3D,
+	float* viewmatrix,
+	float* projmatrix,
+	bool* present)
+{
+	checkFrustum << <(P + 255) / 256, 256 >> > (
+		P,
+		means3D,
+		viewmatrix, projmatrix,
+		present);
+}
+
+CudaRasterizer::GeometryState CudaRasterizer::GeometryState::fromChunk(char*& chunk, size_t P)
+{
+	GeometryState geom;
+	obtain(chunk, geom.depths, P, 128);
+	obtain(chunk, geom.clamped, P * 3, 128);
+	obtain(chunk, geom.internal_radii, P, 128);
+	obtain(chunk, geom.means2D, P, 128);
+	obtain(chunk, geom.cov3D, P * 6, 128);
+	obtain(chunk, geom.conic_opacity, P, 128);
+	obtain(chunk, geom.rgb, P * 3, 128);
+	obtain(chunk, geom.tiles_touched, P, 128);
+	cub::DeviceScan::InclusiveSum(nullptr, geom.scan_size, geom.tiles_touched, geom.tiles_touched, P);
+	obtain(chunk, geom.scanning_space, geom.scan_size, 128);
+	obtain(chunk, geom.point_offsets, P, 128);
+	return geom;
+}
+
+CudaRasterizer::ImageState CudaRasterizer::ImageState::fromChunk(char*& chunk, size_t N)
+{
+	ImageState img;
+	obtain(chunk, img.accum_alpha, N, 128);
+	obtain(chunk, img.n_contrib, N, 128);
+	obtain(chunk, img.ranges, N, 128);
+	int* dummy;
+	int* wummy;
+	cub::DeviceScan::InclusiveSum(nullptr, img.scan_size, dummy, wummy, N);
+	obtain(chunk, img.contrib_scan, img.scan_size, 128);
+
+	obtain(chunk, img.max_contrib, N, 128);
+	obtain(chunk, img.pixel_colors, N * NUM_CHAFFELS, 128);
+	obtain(chunk, img.bucket_count, N, 128);
+	obtain(chunk, img.bucket_offsets, N, 128);
+	cub::DeviceScan::InclusiveSum(nullptr, img.bucket_count_scan_size, img.bucket_count, img.bucket_count, N);
+	obtain(chunk, img.bucket_count_scanning_space, img.bucket_count_scan_size, 128);
+
+	return img;
+}
+
+CudaRasterizer::SampleState CudaRasterizer::SampleState::fromChunk(char *& chunk, size_t C) {
+	SampleState sample;
+	obtain(chunk, sample.bucket_to_tile, C * BLOCK_SIZE, 128);
+	obtain(chunk, sample.T, C * BLOCK_SIZE, 128);
+	obtain(chunk, sample.ar, NUM_CHAFFELS * C * BLOCK_SIZE, 128);
+	return sample;
+}
+
+CudaRasterizer::BinningState CudaRasterizer::BinningState::fromChunk(char*& chunk, size_t P)
+{
+	BinningState binning;
+	obtain(chunk, binning.point_list, P, 128);
+	obtain(chunk, binning.point_list_unsorted, P, 128);
+	obtain(chunk, binning.point_list_keys, P, 128);
+	obtain(chunk, binning.point_list_keys_unsorted, P, 128);
+	cub::DeviceRadixSort::SortPairs(
+		nullptr, binning.sorting_size,
+		binning.point_list_keys_unsorted, binning.point_list_keys,
+		binning.point_list_unsorted, binning.point_list, P);
+	obtain(chunk, binning.list_sorting_space, binning.sorting_size, 128);
+	return binning;
+}
+
+__global__ void zero(int N, int* space)
+{
+	int idx = threadIdx.x + blockDim.x * blockIdx.x;
+	if(idx >= N)
+		return;
+	space[idx] = 0;
+}
+
+__global__ void set(int N, uint32_t* where, int* space)
+{
+	int idx = threadIdx.x + blockDim.x * blockIdx.x;
+	if(idx >= N)
+		return;
+
+	int off = (idx == 0) ? 0 : where[idx-1];
+
+	space[off] = 1;
+}
+
+
+// Forward rendering procedure for differentiable rasterization
+// of Gaussians.
+std::tuple<int,int> CudaRasterizer::Rasterizer::forward(
+	float2* xy_d,
+    float *depths_d,
+	int *radii_d,
+	std::function<char* (size_t)> geometryBuffer,
+	std::function<char* (size_t)> binningBuffer,
+	std::function<char* (size_t)> imageBuffer,
+	std::function<char* (size_t)> sampleBuffer,
+	std::function<int* (size_t)> listBuffer,
+	std::function<float* (size_t)> listBufferRender,
+	std::function<float* (size_t)> listBufferDistance,
+	int* contribCountBuffer, int* contribOffsetBuffer,
+	const int P, int D, int M,
+	const float* background,
+	const int width, int height,
+	const float* means3D,
+	const float* dc,
+	const float* shs,
+	const float* colors_precomp,
+	const float* opacities,
+	const float* scales,
+	const float scale_modifier,
+	const float* rotations,
+	const float* cov3D_precomp,
+	const float* viewmatrix,
+	const float* projmatrix,
+	const float* cam_pos,
+	const float tan_fovx, float tan_fovy,
+	const bool prefiltered,
+	float* out_color,
+	int* radii,
+	bool debug,
+	float* pixel_weights,
+	float* accum_weights,
+	int* reverse_count,
+	float* blend_weights,
+	float* dist_accum)
+{
+	const float focal_y = height / (2.0f * tan_fovy);
+	const float focal_x = width / (2.0f * tan_fovx);
+
+	size_t chunk_size = required<GeometryState>(P);
+	char* chunkptr = geometryBuffer(chunk_size);
+	GeometryState geomState = GeometryState::fromChunk(chunkptr, P);
+
+	if (radii == nullptr)
+	{
+		radii = geomState.internal_radii;
+	}
+
+	dim3 tile_grid((width + BLOCK_X - 1) / BLOCK_X, (height + BLOCK_Y - 1) / BLOCK_Y, 1);
+	dim3 block(BLOCK_X, BLOCK_Y, 1);
+
+	// Dynamically resize image-based auxiliary buffers during training
+	size_t img_chunk_size = required<ImageState>(width * height);
+	char* img_chunkptr = imageBuffer(img_chunk_size);
+	ImageState imgState = ImageState::fromChunk(img_chunkptr, width * height);
+
+	if (NUM_CHAFFELS != 3 && colors_precomp == nullptr)
+	{
+		throw std::runtime_error("For non-RGB, provide precomputed Gaussian colors!");
+	}
+
+	// Run preprocessing per-Gaussian (transformation, bounding, conversion of SHs to RGB)
+	CHECK_CUDA(FORWARD::preprocess(
+		xy_d, depths_d, radii_d,
+		P, D, M,
+		means3D,
+		(glm::vec3*)scales,
+		scale_modifier,
+		(glm::vec4*)rotations,
+		opacities,
+		dc,
+		shs,
+		geomState.clamped,
+		cov3D_precomp,
+		colors_precomp,
+		viewmatrix, projmatrix,
+		(glm::vec3*)cam_pos,
+		width, height,
+		focal_x, focal_y,
+		tan_fovx, tan_fovy,
+		radii,
+		geomState.means2D,
+		geomState.depths,
+		geomState.cov3D,
+		geomState.rgb,
+		geomState.conic_opacity,
+		tile_grid,
+		geomState.tiles_touched,
+		prefiltered
+	), debug);
+
+	// Compute prefix sum over full list of touched tile counts by Gaussians
+	// E.g., [2, 3, 0, 2, 1] -> [2, 5, 5, 7, 8]
+	CHECK_CUDA(cub::DeviceScan::InclusiveSum(geomState.scanning_space, geomState.scan_size, geomState.tiles_touched, geomState.point_offsets, P), debug);
+
+	// Retrieve total number of Gaussian instances to launch and resize aux buffers
+	int num_rendered;
+	CHECK_CUDA(cudaMemcpy(&num_rendered, geomState.point_offsets + P - 1, sizeof(int), cudaMemcpyDeviceToHost), debug);
+
+	size_t binning_chunk_size = required<BinningState>(num_rendered);
+	char* binning_chunkptr = binningBuffer(binning_chunk_size);
+	BinningState binningState = BinningState::fromChunk(binning_chunkptr, num_rendered);
+
+	// For each instance to be rendered, produce adequate [ tile | depth ] key 
+	// and corresponding dublicated Gaussian indices to be sorted
+	duplicateWithKeys << <(P + 255) / 256, 256 >> > (
+		P,
+		geomState.means2D,
+		geomState.conic_opacity,
+		geomState.depths,
+		geomState.point_offsets,
+		binningState.point_list_keys_unsorted,
+		binningState.point_list_unsorted,
+		radii,
+		tile_grid,
+		nullptr);
+	CHECK_CUDA(, debug);
+
+	int bit = getHigherMsb(tile_grid.x * tile_grid.y);
+
+	// Sort complete list of (duplicated) Gaussian indices by keys
+	CHECK_CUDA(cub::DeviceRadixSort::SortPairs(
+		binningState.list_sorting_space,
+		binningState.sorting_size,
+		binningState.point_list_keys_unsorted, binningState.point_list_keys,
+		binningState.point_list_unsorted, binningState.point_list,
+		num_rendered, 0, 32 + bit), debug);
+
+	CHECK_CUDA(cudaMemset(imgState.ranges, 0, tile_grid.x * tile_grid.y * sizeof(uint2)), debug);
+
+	// Identify start and end of per-tile workloads in sorted list
+	if (num_rendered > 0)
+		identifyTileRanges << <(num_rendered + 255) / 256, 256 >> > (
+			num_rendered,
+			binningState.point_list_keys,
+			imgState.ranges);
+	CHECK_CUDA(, debug);
+
+ 	// bucket count
+	int num_tiles = tile_grid.x * tile_grid.y;
+	perTileBucketCount<<<(num_tiles + 255) / 256, 256>>>(num_tiles, imgState.ranges, imgState.bucket_count);
+	CHECK_CUDA(cub::DeviceScan::InclusiveSum(imgState.bucket_count_scanning_space, imgState.bucket_count_scan_size, imgState.bucket_count, imgState.bucket_offsets, num_tiles), debug);
+	unsigned int bucket_sum;
+	CHECK_CUDA(cudaMemcpy(&bucket_sum, imgState.bucket_offsets + num_tiles - 1, sizeof(unsigned int), cudaMemcpyDeviceToHost), debug);
+	// create a state to store. size is number is the total number of buckets * block_size
+	size_t sample_chunk_size = required<SampleState>(bucket_sum);
+	char* sample_chunkptr = sampleBuffer(sample_chunk_size);
+	SampleState sampleState = SampleState::fromChunk(sample_chunkptr, bucket_sum);
+
+	// Let each tile blend its range of Gaussians independently in parallel
+	const float* feature_ptr = colors_precomp != nullptr ? colors_precomp : geomState.rgb;
+	CHECK_CUDA(FORWARD::render(
+		tile_grid, block,
+		imgState.ranges,
+		binningState.point_list,
+		imgState.bucket_offsets, sampleState.bucket_to_tile,
+		sampleState.T, sampleState.ar,
+		width, height,
+		geomState.means2D,
+		feature_ptr,
+		geomState.conic_opacity,
+		imgState.accum_alpha,
+		imgState.n_contrib,
+		imgState.max_contrib,
+		imgState.pixel_colors,
+		background,
+		out_color,
+		contribCountBuffer,
+		contribOffsetBuffer,
+		imgState.contrib_scan,
+		imgState.scan_size,
+		listBuffer, listBufferRender, listBufferDistance,
+		pixel_weights,
+		accum_weights,
+		reverse_count,
+		blend_weights,
+		dist_accum), debug);
+
+	return std::make_tuple(num_rendered, bucket_sum);
+}
+
+// Produce necessary gradients for optimization, corresponding
+// to forward render pass
+void CudaRasterizer::Rasterizer::backward(
+	const int P, int D, int M, int R, int B,
+	const float* background,
+	const int width, int height,
+	const float* means3D,
+	const float* dc,
+	const float* shs,
+	const float* colors_precomp,
+	const float* scales,
+	const float scale_modifier,
+	const float* rotations,
+	const float* cov3D_precomp,
+	const float* viewmatrix,
+	const float* projmatrix,
+	const float* campos,
+	const float tan_fovx, float tan_fovy,
+	const int* radii,
+	char* geom_buffer,
+	char* binning_buffer,
+	char* img_buffer,
+	char* sample_buffer,
+	const float* dL_dpix,
+	float* dL_dmean2D,
+	float* dL_dconic,
+	float* dL_dopacity,
+	float* dL_dcolor,
+	float* dL_dmean3D,
+	float* dL_dcov3D,
+	float* dL_ddc,
+	float* dL_dsh,
+	float* dL_dscale,
+	float* dL_drot,
+	bool debug)
+{
+	GeometryState geomState = GeometryState::fromChunk(geom_buffer, P);
+	BinningState binningState = BinningState::fromChunk(binning_buffer, R);
+	ImageState imgState = ImageState::fromChunk(img_buffer, width * height);
+	SampleState sampleState = SampleState::fromChunk(sample_buffer, B);
+
+	if (radii == nullptr)
+	{
+		radii = geomState.internal_radii;
+	}
+
+	const float focal_y = height / (2.0f * tan_fovy);
+	const float focal_x = width / (2.0f * tan_fovx);
+
+	const dim3 tile_grid((width + BLOCK_X - 1) / BLOCK_X, (height + BLOCK_Y - 1) / BLOCK_Y, 1);
+	const dim3 block(BLOCK_X, BLOCK_Y, 1);
+
+	// Compute loss gradients w.r.t. 2D mean position, conic matrix,
+	// opacity and RGB of Gaussians from per-pixel loss gradients.
+	// If we were given precomputed colors and not SHs, use them.
+	const float* color_ptr = (colors_precomp != nullptr) ? colors_precomp : geomState.rgb;
+	CHECK_CUDA(BACKWARD::render(
+		tile_grid,
+		block,
+		imgState.ranges,
+		binningState.point_list,
+		width, height, R, B,
+		imgState.bucket_offsets,
+		sampleState.bucket_to_tile,
+		sampleState.T,
+		sampleState.ar,
+		background,
+		geomState.means2D,
+		geomState.conic_opacity,
+		color_ptr,
+		imgState.accum_alpha,
+		imgState.n_contrib,
+		imgState.max_contrib,
+		imgState.pixel_colors,
+		dL_dpix,
+		(float3*)dL_dmean2D,
+		(float4*)dL_dconic,
+		dL_dopacity,
+		dL_dcolor), debug);
+
+	// // Take care of the rest of preprocessing. Was the precomputed covariance
+	// // given to us or a scales/rot pair? If precomputed, pass that. If not,
+	// // use the one we computed ourselves.
+	const float* cov3D_ptr = (cov3D_precomp != nullptr) ? cov3D_precomp : geomState.cov3D;
+	CHECK_CUDA(BACKWARD::preprocess(P, D, M,
+		(float3*)means3D,
+		radii,
+		dc,
+		shs,
+		geomState.clamped,
+		(glm::vec3*)scales,
+		(glm::vec4*)rotations,
+		scale_modifier,
+		cov3D_ptr,
+		viewmatrix,
+		projmatrix,
+		focal_x, focal_y,
+		tan_fovx, tan_fovy,
+		(glm::vec3*)campos,
+		(float3*)dL_dmean2D,
+		dL_dconic,
+		(glm::vec3*)dL_dmean3D,
+		dL_dcolor,
+		dL_dcov3D,
+		dL_ddc,
+		dL_dsh,
+		(glm::vec3*)dL_dscale,
+		(glm::vec4*)dL_drot), debug);
+}

--- a/taminggs/rasterizer_impl.h
+++ b/taminggs/rasterizer_impl.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#pragma once
+
+#include <iostream>
+#include <vector>
+#include "rasterizer.h"
+#include <cuda_runtime_api.h>
+
+namespace CudaRasterizer
+{
+	template <typename T>
+	static void obtain(char*& chunk, T*& ptr, std::size_t count, std::size_t alignment)
+	{
+		std::size_t offset = (reinterpret_cast<std::uintptr_t>(chunk) + alignment - 1) & ~(alignment - 1);
+		ptr = reinterpret_cast<T*>(offset);
+		chunk = reinterpret_cast<char*>(ptr + count);
+	}
+
+	struct GeometryState
+	{
+		size_t scan_size;
+		float* depths;
+		char* scanning_space;
+		bool* clamped;
+		int* internal_radii;
+		float2* means2D;
+		float* cov3D;
+		float4* conic_opacity;
+		float* rgb;
+		uint32_t* point_offsets;
+		uint32_t* tiles_touched;
+
+		static GeometryState fromChunk(char*& chunk, size_t P);
+	};
+
+	struct ImageState
+	{
+		uint32_t *bucket_count;
+		uint32_t *bucket_offsets;
+		size_t bucket_count_scan_size;
+		char * bucket_count_scanning_space;
+		float* pixel_colors;
+		uint32_t* max_contrib;
+
+		size_t scan_size;
+		uint2* ranges;
+		uint32_t* n_contrib;
+		float* accum_alpha;
+		char* contrib_scan;
+
+		static ImageState fromChunk(char*& chunk, size_t N);
+	};
+
+	struct BinningState
+	{
+		size_t scan_size;
+		size_t sorting_size;
+		uint64_t* point_list_keys_unsorted;
+		uint64_t* point_list_keys;
+		uint32_t* point_list_unsorted;
+		uint32_t* point_list;
+		int* scan_src;
+		int* scan_dst;
+		char* scan_space;
+		char* list_sorting_space;
+
+		static BinningState fromChunk(char*& chunk, size_t P);
+	};
+
+	struct SampleState
+	{
+		uint32_t *bucket_to_tile;
+		float *T;
+		float *ar;
+		static SampleState fromChunk(char*& chunk, size_t C);
+	};
+
+	template<typename T> 
+	size_t required(size_t P)
+	{
+		char* size = nullptr;
+		T::fromChunk(size, P);
+		return ((size_t)size) + 128;
+	}
+};


### PR DESCRIPTION
This is the submission for bounty 001. This achieves a speedup of 70% on a 4090 compared to the baseline. The improvements done are as follows

- Caches the images dynamically on gpu and cpu
- Removes the cat of the sh
- Adds taminggs kernels + FlashGS accurate tile intersection
- uses the fused adam with a bias corrected kernel without the visibility mask
- precomp and cache the projmat and viewmats
- (optional) adds support for udpating the shN after every 16 steps (but degrades performance)
- (optional) Implements [DashGS](https://dashgaussian.github.io/) dft based frequency scheduler (but metrics are slightly worse)

optional implementations were turned off while computing the 70% speedup 