### PR TITLE
fix compile error if using ENABLE_CUDA_GL_INTEROP=OFF

### DIFF
--- a/src/visualizer/rendering/renderer.hpp
+++ b/src/visualizer/rendering/renderer.hpp
@@ -4,6 +4,7 @@
 #include "internal/viewport.hpp"
 #include "rendering/framebuffer.hpp"
 #include "rendering/shader.hpp"
+#include <memory>
 
 #ifdef CUDA_GL_INTEROP_ENABLED
 #include "rendering/cuda_gl_interop.hpp" // Add path and extension


### PR DESCRIPTION
Fix for std pointer types if running cmake with -DENABLE_CUDA_GL_INTEROP=OFF They are probably included indirectly otherwise.

For me I were already disabling the interop earlier in the cmake file manually since I had issues with it on WSL (windows + Ubuntu 24).
This flag from earlier PR makes it easier but made it fail to compile.
This fixes it for me, hope it helps others too.