### PR TITLE
Fix memory leak on windows when it is not longer refining

### DIFF
--- a/src/default_strategy.cpp
+++ b/src/default_strategy.cpp
@@ -395,13 +395,17 @@ void DefaultStrategy::post_backward(int iter, gs::RenderOutput& render_output) {
         if (_params->stop_refine_scale2d > 0) {
             _radii.zero_();
         }
-
-        c10::cuda::CUDACachingAllocator::emptyCache();
     }
 
     if (iter % _params->reset_every == 0 && iter > 0) {
         reset_opacity();
     }
+
+#ifdef _WIN32
+    // Windows doesn't support CUDACachingAllocator expandable_segments
+    if (iter % 10 == 0 || iter == _params->stop_refine || iter == _params->iterations)
+        c10::cuda::CUDACachingAllocator::emptyCache();
+#endif
 }
 
 void DefaultStrategy::step(int iter) {

--- a/src/mcmc.cpp
+++ b/src/mcmc.cpp
@@ -375,15 +375,16 @@ void MCMC::post_backward(int iter, gs::RenderOutput& render_output) {
 
         // Add new Gaussians
         add_new_gs();
-
-#ifdef _WIN32
-        // Windows doesn't support CUDACachingAllocator expandable_segments
-        c10::cuda::CUDACachingAllocator::emptyCache();
-#endif
     }
 
     // Inject noise to positions
     inject_noise();
+
+#ifdef _WIN32
+    // Windows doesn't support CUDACachingAllocator expandable_segments
+    if (iter % 10 == 0 || iter == _params->stop_refine || iter == _params->iterations)
+        c10::cuda::CUDACachingAllocator::emptyCache();
+#endif
 }
 
 void MCMC::step(int iter) {


### PR DESCRIPTION
In the previous method after stopping refining a memory leak was happening in windows.

It also avoids per-step cache flush; minor increase in memory between trims is expected while avoiding the overhead of clearing on every step.