### PR TITLE
bugfix camera controls

### DIFF
--- a/include/core/events.hpp
+++ b/include/core/events.hpp
@@ -210,6 +210,7 @@ namespace gs {
         namespace internal {
             EVENT(TrainerReady, );
             EVENT(TrainingReadyToStart, );
+            EVENT(WindowFocusLost, );
             EVENT(RenderRequest,
                   glm::mat3 view_rotation;
                   glm::vec3 view_translation;

--- a/include/core/training_progress.hpp
+++ b/include/core/training_progress.hpp
@@ -24,7 +24,7 @@ public:
         // Configure the progress bar after creation using constructor syntax
         progress_bar_->set_option(indicators::option::BarWidth(40));
         progress_bar_->set_option(indicators::option::Start("["));
-        
+
         // Use ASCII characters on Windows, Unicode on other platforms
 #ifdef _WIN32
         progress_bar_->set_option(indicators::option::Fill("="));

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -56,8 +56,7 @@ namespace gs::gui {
         ImGuiIO& io = ImGui::GetIO();
         io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
         io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
-        io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;   // Enable Docking
-        io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable; // Enable Multi-Viewport
+        io.ConfigFlags |= ImGuiConfigFlags_DockingEnable; // Enable Docking
         io.ConfigWindowsMoveFromTitleBarOnly = true;
 
         // Platform/Renderer initialization
@@ -107,16 +106,20 @@ namespace gs::gui {
         ImGui_ImplOpenGL3_NewFrame();
         ImGui_ImplGlfw_NewFrame();
 
-        // Check if mouse is in viewport before ImGui processes the frame
+        // CRITICAL: Check mouse state BEFORE ImGui::NewFrame()
+        // This is important because ImGui updates WantCaptureMouse during NewFrame()
         ImVec2 mouse_pos = ImGui::GetMousePos();
         bool mouse_in_viewport = isPositionInViewport(mouse_pos.x, mouse_pos.y);
 
         ImGui::NewFrame();
 
-        // Prevent ImGui from capturing right/middle mouse buttons when in viewport
-        if (mouse_in_viewport && (ImGui::IsMouseDown(ImGuiMouseButton_Right) ||
-                                  ImGui::IsMouseDown(ImGuiMouseButton_Middle))) {
-            ImGui::GetIO().WantCaptureMouse = false;
+        // Override ImGui's mouse capture for right/middle buttons when in viewport
+        // This ensures that camera controls work properly
+        if (mouse_in_viewport && !ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow)) {
+            if (ImGui::IsMouseDown(ImGuiMouseButton_Right) ||
+                ImGui::IsMouseDown(ImGuiMouseButton_Middle)) {
+                ImGui::GetIO().WantCaptureMouse = false;
+            }
         }
 
         // Create main dockspace

--- a/src/visualizer/input/camera_controller.cpp
+++ b/src/visualizer/input/camera_controller.cpp
@@ -223,4 +223,10 @@ namespace gs {
         handleWasd(event);
     }
 
+    void CameraController::resetStates() {
+        is_panning_ = false;
+        is_rotating_ = false;
+        is_orbiting_ = false;
+    }
+
 } // namespace gs

--- a/src/visualizer/input/camera_controller.hpp
+++ b/src/visualizer/input/camera_controller.hpp
@@ -28,6 +28,7 @@ namespace gs {
         void handleMouseMove(const InputHandler::MouseMoveEvent& event);
         void handleMouseScroll(const InputHandler::MouseScrollEvent& event);
         void handleKey(const InputHandler::KeyEvent& event);
+        void resetStates();
 
     private:
         // Check if viewport is focused

--- a/src/visualizer/input/input_handler.cpp
+++ b/src/visualizer/input/input_handler.cpp
@@ -7,7 +7,7 @@
 // clang-format on
 
 #include <algorithm>
-#include <imgui.h> // Add ImGui for checking its state
+#include <imgui.h>
 #include <print>
 
 namespace gs {

--- a/src/visualizer/input/input_manager.cpp
+++ b/src/visualizer/input/input_manager.cpp
@@ -20,7 +20,7 @@ namespace gs::visualizer {
         // Subscribe to WindowFocusLost to reset camera states
         events::internal::WindowFocusLost::when([this](const auto&) {
             if (camera_controller_) {
-                camera_controller_->resetStates(); // New method: is_panning_ = is_rotating_ = is_orbiting_ = false;
+                camera_controller_->resetStates();
             }
         });
     }

--- a/src/visualizer/input/input_manager.cpp
+++ b/src/visualizer/input/input_manager.cpp
@@ -16,6 +16,13 @@ namespace gs::visualizer {
         events::cmd::GoToCamView::when([this](const auto& event) {
             handleGoToCamView(event);
         });
+
+        // Subscribe to WindowFocusLost to reset camera states
+        events::internal::WindowFocusLost::when([this](const auto&) {
+            if (camera_controller_) {
+                camera_controller_->resetStates(); // New method: is_panning_ = is_rotating_ = is_orbiting_ = false;
+            }
+        });
     }
 
     void InputManager::handleGoToCamView(const events::cmd::GoToCamView& event) {

--- a/src/visualizer/window/window_manager.cpp
+++ b/src/visualizer/window/window_manager.cpp
@@ -1,4 +1,5 @@
 #include "window_manager.hpp"
+#include "core/events.hpp"
 // clang-format off
 // CRITICAL: GLAD must be included before GLFW to avoid OpenGL header conflicts
 #include <glad/glad.h>
@@ -8,6 +9,15 @@
 #include <print>
 
 namespace gs {
+
+    static void window_focus_callback(GLFWwindow* window, int focused) {
+        if (!focused) {
+            events::internal::WindowFocusLost{}.emit();
+            std::println("[WindowManager] Window lost focus");
+        } else {
+            std::println("[WindowManager] Window gained focus");
+        }
+    }
 
     WindowManager::WindowManager(const std::string& title, int width, int height)
         : title_(title),
@@ -57,6 +67,9 @@ namespace gs {
             glfwTerminate();
             return false;
         }
+
+        // Set window focus callback
+        glfwSetWindowFocusCallback(window_, window_focus_callback);
 
         // Enable vsync by default
         glfwSwapInterval(1);


### PR DESCRIPTION
- Fixes: Camera didn't work sometimes.
- Fixes: Camera movement break after dragging Window, resizing, or switching the app.

This should be more robust!