### PR TITLE
save vcpkg.json as UTF-8 instead of UTF-8-BOM

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,22 +1,22 @@
-﻿{
-  "builtin-baseline": "4f8fe05871555c1798dbcb1957d0d595e94f7b57",
-  "dependencies": [
-    "args",
-    "glad",
-    "glfw3",
-    "glm",
-    "gtest",
-    {
-      "name": "imgui",
-      "features": [
-        "docking-experimental",
-        "glfw-binding",
-        "opengl3-binding"
-      ]
-    },
-    "nlohmann-json",
-    "spdlog",
-    "tbb",
-    "freetype"
-  ]
+{
+    "builtin-baseline": "4f8fe05871555c1798dbcb1957d0d595e94f7b57",
+    "dependencies": [
+        "args",
+        "glad",
+        "glfw3",
+        "glm",
+        "gtest",
+        {
+            "name": "imgui",
+            "features": [
+                "docking-experimental",
+                "glfw-binding",
+                "opengl3-binding"
+            ]
+        },
+        "nlohmann-json",
+        "spdlog",
+        "tbb",
+        "freetype"
+    ]
 }


### PR DESCRIPTION
based on the suggestion here: https://github.com/MrNeRF/gaussian-splatting-cuda/pull/317#issuecomment-3208154710