### PR TITLE
restore-keys with rolling cache for ccache in github actions

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -53,7 +53,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.cache/ccache
-          key: ccache-${{ runner.os }}
+          key: ccache-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ runner.os }}-
 
       - name: Configure with CMake
         run: |
@@ -61,10 +63,3 @@ jobs:
 
       - name: Build
         run: cmake --build build --parallel 1
-
-      - name: Save updated ccache
-        if: always()
-        uses: actions/cache/save@v4
-        with:
-          path: /github/home/.cache/ccache
-          key: ccache-${{ runner.os }}


### PR DESCRIPTION
doesn't seem possible to overwrite the ccache when it's in use, try using rolling cache this time and see if it works 