### PR TITLE
vcpkg hardcode approach alternative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ data
 test.py
 *.nsys-rep
 testdata
+vcpkg/
+vcpkg/**
 
 *.pt
 !weights/*.pt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,11 @@
 # windows/linux platform independent
 set(RAW_VCPKG_PATH $ENV{VCPKG_ROOT})
 file(TO_CMAKE_PATH "${RAW_VCPKG_PATH}" VCPKG_ROOT)
-set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
+
+if ("${CMAKE_TOOLCHAIN_FILE}" STREQUAL "")
+    message(STATUS "user didn't specify CMAKE_TOOLCHAIN_FILE manually, so let's use default -> ${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
+    set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
+endif()
 
 cmake_minimum_required(VERSION 3.24...3.30)
 project(gaussian_splatting_cuda LANGUAGES CUDA CXX C)

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ cmake --build build -- -j$(nproc)
 # Set up vcpkg (one-time setup)
 git clone https://github.com/microsoft/vcpkg.git
 cd vcpkg && ./bootstrap-vcpkg.sh -disableMetrics && cd ..
+
+## If you want you can specify vcpkg locally without globally setting env variable (see -DCMAKE_TOOLCHAIN_FILE version)
 export VCPKG_ROOT=/path/to/vcpkg  # Add to ~/.bashrc
 
 # Clone repository
@@ -113,6 +115,10 @@ rm libtorch-cxx11-abi-shared-with-deps-2.7.0+cu128.zip
 
 # Build
 cmake -B build -DCMAKE_BUILD_TYPE=Release -G Ninja
+
+## Or if you want you can specify your own vcpkg 
+# cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="<path-to-vcpkg>/scripts/buildsystems/vcpkg.cmake" -G Ninja 
+
 cmake --build build -- -j$(nproc)
 ```
 
@@ -127,6 +133,8 @@ Run in **VS Developer Command Prompt**:
 # Set up vcpkg (one-time setup)
 git clone https://github.com/microsoft/vcpkg.git
 cd vcpkg && .\bootstrap-vcpkg.bat -disableMetrics && cd ..
+
+## If you want you can specify vcpkg locally without globally setting env variable (see -DCMAKE_TOOLCHAIN_FILE version)
 set VCPKG_ROOT=%CD%\vcpkg
 
 # Clone repository
@@ -150,6 +158,10 @@ del libtorch-release.zip
 
 # Build
 cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+## Or if you want you can specify your own vcpkg 
+# cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="<path-to-vcpkg>/scripts/buildsystems/vcpkg.cmake"
+
 cmake --build build --config Release -j
 ```
 


### PR DESCRIPTION
Hello it is me ~mario~ maybe you didn't forget about our convo from like yesterday (?), so yeah I would like to fix the https://github.com/MrNeRF/gaussian-splatting-cuda/issues/357

But for now I don't like the approach for hardcoding vcpkg using env variables, so it is really better to clone vcpkg to the root folder of repo project.

So it is really nice to specify cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="./vcpkg/scripts/buildsystems/vcpkg.cmake" because we could possibly have a case when user nuked its vcpkg and a scenario IT was used for different projects (not just for gaussian splatting cuda) and since it was ruined he can't just easily resolve the dependencies (or remember them well) that were used and handled by single vcpkg instance that was specified and used by these projects just because it was used the route through env variables it might be a not good situation for you to receive comments about bad user experience just because they got not properly working vcpkg and now they can't build their projects...

Yeah, isolating vcpkg and providing ability to manually specifying own instance of vcpkg is a quite nice feature :D
I hope you find this request as reasonable.

So if you don't mind I just made in CMake a default handling if/endif for a case when user went to default route like using env variables (backward compatibility) BUT if it was specified like through  -DCMAKE_TOOLCHAIN_FILE then all is fine and we do as is like env variable route.

Maybe my update of readme.md is not beauty or how you would expect to see so I hope you can fix it as you wish or like.

Cheers