### PR TITLE
initialize training in setup

### DIFF
--- a/src/visualizer/training/training_manager.cpp
+++ b/src/visualizer/training/training_manager.cpp
@@ -35,6 +35,17 @@ namespace gs {
 
             setState(State::Ready);
 
+            // Initialize trainer if not already initialized
+            if (!trainer_->isInitialized()) {
+                LOG_INFO("Initializing trainer");
+                auto init_result = initializeTrainerFromProject();
+                if (!init_result) {
+                    LOG_ERROR("Failed to initialize trainer: {}", init_result.error());
+                    last_error_ = init_result.error();
+                    setState(State::Error);
+                }
+            }
+
             // Trainer is ready
             events::internal::TrainerReady{}.emit();
             LOG_INFO("Trainer ready for training");


### PR DESCRIPTION
currently you don't see the images list in the scene panel when loading a scene, because the trainer is only initialized
in the start training. I think it is ok to call initialization on "set trainer".
it is either that or separate the loader from the initialization. 