### PR TITLE
Fix for correct linking python libraries based on different build configurations in Visual Studio for Windows (and other platforms); Ignoring additional build folder namings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ test.py
 testdata
 vcpkg/
 vcpkg/**
+vcpkg_*/**
+vcpkg_*/
 
 *.pt
 !weights/*.pt

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ vcpkg/
 vcpkg/**
 vcpkg_*/**
 vcpkg_*/
+build*/
+build*/**
 
 *.pt
 !weights/*.pt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,14 +30,41 @@ set(BUILD_CUDA_ALL_MIN_SM "86" CACHE STRING "Minimum SM (compute capability) use
 
 # Set Torch_DIR based on platform and build type
 if (WIN32)
-    if(CMAKE_CONFIGURATION_TYPES)
+    if(CMAKE_CONFIGURATION_TYPES AND "${CMAKE_BUILD_TYPE}" STREQUAL "")
         # https://github.com/pytorch/pytorch/issues/155667
         set(Torch_DIR "${PROJ_ROOT_DIR}/external/release/libtorch/share/cmake/Torch")
+        message(STATUS "[${PROJECT_NAME}] User didn't specify -DCMAKE_BUILD_TYPE so use this path for searching libtorch -> ${PROJ_ROOT_DIR}/external/release/libtorch/share/cmake/Torch")
+
+        if (NOT EXISTS "${PROJ_ROOT_DIR}/external/release/")
+            message(FATAL_ERROR "you don't have a such path ${PROJ_ROOT_DIR}/external/release/ on your disk")
+        endif()
+
+        if (NOT EXISTS "${PROJ_ROOT_DIR}/external/release/libtorch/")
+            message(FATAL_ERROR "you don't have an extracted pre-installed libtorch (${PROJ_ROOT_DIR}/external/release/libtorch)!")
+        endif()
     else()
         if (CMAKE_BUILD_TYPE STREQUAL "Release")
             set(Torch_DIR "${PROJ_ROOT_DIR}/external/release/libtorch/share/cmake/Torch")
+            message(STATUS "[${PROJECT_NAME}] User specified -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} so let's search libtorch by this path -> ${PROJ_ROOT_DIR}/external/release/libtorch/share/cmake/Torch")
+
+            if (NOT EXISTS "${PROJ_ROOT_DIR}/external/release/")
+                message(FATAL_ERROR "you don't have a such path ${PROJ_ROOT_DIR}/external/release/ on your disk")
+            endif()
+
+            if (NOT EXISTS "${PROJ_ROOT_DIR}/external/release/libtorch")
+                message(FATAL_ERROR "you don't have an extracted pre-installed libtorch (${PROJ_ROOT_DIR}/external/release/libtorch)!")
+            endif()
         elseif (CMAKE_BUILD_TYPE STREQUAL "Debug")
             set(Torch_DIR "${PROJ_ROOT_DIR}/external/debug/libtorch/share/cmake/Torch")
+            message(STATUS "[${PROJECT_NAME}] User specified -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} so let's search libtorch by this path -> ${PROJ_ROOT_DIR}/external/debug/libtorch/share/cmake/Torch")
+
+            if (NOT EXISTS "${PROJ_ROOT_DIR}/external/debug/")
+                message(FATAL_ERROR "you don't have a such path ${PROJ_ROOT_DIR}/external/debug/ on your disk")
+            endif()
+
+            if (NOT EXISTS "${PROJ_ROOT_DIR}/external/debug/libtorch")
+                message(FATAL_ERROR "you don't have an extracted pre-installed libtorch (${PROJ_ROOT_DIR}/external/debug/libtorch)!")
+            endif()
         else()
             message(FATAL_ERROR "libtorch binaries only available for Debug and Release on Windows. Current build type: '${CMAKE_BUILD_TYPE}'")
         endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,7 +416,7 @@ target_link_libraries(${PROJECT_NAME}
         gs_kernels
         gsplat_backend
         fastgs_backend
-        Python3::Python
+        ${Python3_LIBRARIES}
         ${OPENGL_LIBRARIES}
         CUDA::cudart
         spdlog::spdlog


### PR DESCRIPTION
@MrNeRF hi you asked for fixing python3xx_d.lib and as you requested I responded :) 

I tested just generated project as usual we do and there indeed a correct python3xx_d.lib as expected (before my fixes it was linking release version of python instead of debug version of library like *_d.lib)