### PR TITLE
Add background modulation during training (--bg-modulation flag)

### DIFF
--- a/include/core/parameters.hpp
+++ b/include/core/parameters.hpp
@@ -36,6 +36,7 @@ namespace gs {
             std::vector<size_t> eval_steps = {7'000, 30'000}; // Steps to evaluate the model
             std::vector<size_t> save_steps = {7'000, 30'000}; // Steps to save the model
             bool skip_intermediate_saving = false;            // Skip saving intermediate results and only save final output
+            bool bg_modulation = false;                       // Enable sinusoidal background modulation
             bool enable_eval = false;                         // Only evaluate when explicitly enabled
             bool rc = false;                                  // Workaround for reality captures - doesn't properly convert COLMAP camera model
             bool enable_save_eval_images = true;              // Save during evaluation images

--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -108,6 +108,7 @@ namespace {
             ::args::Flag enable_save_eval_images(parser, "save_eval_images", "Save eval images and depth maps", {"save-eval-images"});
             ::args::Flag save_depth(parser, "save_depth", "Save depth maps during training", {"save-depth"});
             ::args::Flag skip_intermediate_saving(parser, "skip_intermediate", "Skip saving intermediate results and only save final output", {"skip-intermediate"});
+            ::args::Flag bg_modulation(parser, "bg_modulation", "Enable sinusoidal background modulation mixed with base background", {"bg-modulation"});
             ::args::Flag random(parser, "random", "Use random initialization instead of SfM", {"random"});
             ::args::Flag gut(parser, "gut", "Enable GUT mode", {"gut"});
             ::args::Flag rc(parser, "rc", "Workaround for reality captures - doesn't properly convert COLMAP camera model", {"rc"});
@@ -275,6 +276,7 @@ namespace {
                                         antialiasing_flag = bool(antialiasing),
                                         enable_save_eval_images_flag = bool(enable_save_eval_images),
                                         skip_intermediate_saving_flag = bool(skip_intermediate_saving),
+                                        bg_modulation_flag = bool(bg_modulation),
                                         random_flag = bool(random),
                                         gut_flag = bool(gut)]() {
                 auto& opt = params.optimization;
@@ -317,6 +319,7 @@ namespace {
                 setFlag(antialiasing_flag, opt.antialiasing);
                 setFlag(enable_save_eval_images_flag, opt.enable_save_eval_images);
                 setFlag(skip_intermediate_saving_flag, opt.skip_intermediate_saving);
+                setFlag(bg_modulation_flag, opt.bg_modulation);
                 setFlag(random_flag, opt.random);
                 setFlag(gut_flag, opt.gut);
             };

--- a/src/loader/formats/ply.cpp
+++ b/src/loader/formats/ply.cpp
@@ -153,7 +153,7 @@ namespace gs::loader {
                 return false;
             }
 
-            struct stat st {};
+            struct stat st{};
             if (fstat(fd, &st) < 0) {
                 LOG_ERROR("Failed to stat file: {}", filepath.string());
                 return false;

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -360,6 +360,102 @@ namespace gs::training {
         }
     }
 
+    inline float inv_weight_piecewise(int step, int max_steps) {
+        // Phases by fraction of training
+        const float phase = std::max(0.f, std::min(1.f, step / float(std::max(1, max_steps))));
+
+        const float limit_hi = 1.0f / 4.0f;  // start limit
+        const float limit_mid = 2.0f / 4.0f; // middle limit
+        const float limit_lo = 3.0f / 4.0;   // final limit
+
+        const float weight_hi = 1.0f;  // start weight
+        const float weight_mid = 0.5f; // middle weight
+        const float weight_lo = 0.0f;  // final weight
+
+        if (phase < limit_hi) {
+            return weight_hi; // hold until bypasses the start limit
+        } else if (phase < limit_mid) {
+            const float t = (phase - limit_hi) / (limit_mid - limit_hi);
+            return weight_hi + (weight_mid - weight_hi) * t; // decay to mid value
+        } else {
+            const float t = (phase - limit_mid) / (limit_lo - limit_mid);
+            return weight_mid + (weight_lo - weight_mid) * t; // decay to final value
+        }
+    }
+
+    torch::Tensor sine_background_for_step(
+        int step, int periodR = 37, int periodG = 41, int periodB = 43, bool grayscale_only = false, float jitter_amp = 0.03f) {
+        const float eps = 1e-4f;
+        auto opts = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
+        const float two_pi = M_PI * 2.0f;
+
+        // Phase 0..2PI
+        const float tR = (periodR > 0) ? float(step % periodR) / float(periodR) : 0.0f;
+        const float phaseR = two_pi * tR;
+
+        const float tG = (periodG > 0) ? float(step % periodG) / float(periodG) : 0.0f;
+        const float phaseG = two_pi * tG;
+
+        const float tB = (periodB > 0) ? float(step % periodB) / float(periodB) : 0.0f;
+        const float phaseB = two_pi * tB;
+
+        torch::Tensor bg;
+        if (grayscale_only) {
+            // Grayscale: g in [0,1]
+            float g = 0.5f * (1.0f + std::sin(phaseG));
+            bg = torch::tensor({g, g, g}, opts);
+        } else {
+            // Phase-shifted RGB: covers the color wheel over the cycle
+            float r = 0.5f * (1.0f + std::sin(phaseR + 0.0f * two_pi / 3.0f));
+            float g = 0.5f * (1.0f + std::sin(phaseG + 1.0f * two_pi / 3.0f));
+            float b = 0.5f * (1.0f + std::sin(phaseB + 2.0f * two_pi / 3.0f));
+            bg = torch::tensor({r, g, b}, opts);
+        }
+
+        // Small jitter to prevent exact periodic lock-in
+        if (jitter_amp > 0.0f) {
+            auto jitter = (torch::rand({3}, opts) - 0.5f) * (2.0f * jitter_amp);
+            bg = (bg + jitter).clamp(eps, 1.0f - eps);
+        } else {
+            bg = bg.clamp(eps, 1.0f - eps);
+        }
+        return bg;
+    }
+
+    // Helper to ensure buf matches base (defined, dtype, device, shape)
+    static inline void ensure_like(torch::Tensor& buf, const torch::Tensor& base) {
+        bool need = !buf.defined() || buf.dtype() != base.dtype() || buf.device() != base.device() || buf.sizes().vec() != base.sizes().vec();
+        if (need)
+            buf = torch::empty_like(base);
+    }
+
+    torch::Tensor& Trainer::background_for_step(int iter) {
+        torch::NoGradGuard no_grad;
+        const auto& opt = params_.optimization;
+
+        // Fast path: modulation disabled: return base background_
+        if (!opt.bg_modulation) {
+            return background_;
+        }
+
+        const float w_mix = inv_weight_piecewise(iter, opt.iterations);
+        if (w_mix <= 0.0f) {
+            return background_;
+        }
+
+        // Generate per-iteration sine background
+        auto sine_bg = sine_background_for_step(iter);
+
+        // Ensure reusable buffer exists
+        ensure_like(bg_mix_buffer_, background_);
+
+        bg_mix_buffer_.copy_(background_); // d2d copy of 3 floats
+        bg_mix_buffer_.mul_(1.0f - w_mix);
+        bg_mix_buffer_.add_(sine_bg, w_mix);
+
+        return bg_mix_buffer_; // const ref to mixed background
+    }
+
     std::expected<Trainer::StepResult, std::string> Trainer::train_step(
         int iter,
         Camera* cam,
@@ -408,12 +504,14 @@ namespace gs::training {
             auto adjusted_cam_pos = poseopt_module_->forward(cam->world_view_transform(), torch::tensor({cam->uid()}));
             auto adjusted_cam = Camera(*cam, adjusted_cam_pos);
 
+            torch::Tensor& bg = background_for_step(iter);
+
             RenderOutput r_output;
             // Use the render mode from parameters
             if (!params_.optimization.gut) {
-                r_output = fast_rasterize(adjusted_cam, strategy_->get_model(), background_);
+                r_output = fast_rasterize(adjusted_cam, strategy_->get_model(), bg);
             } else {
-                r_output = rasterize(adjusted_cam, strategy_->get_model(), background_, 1.0f, false, false, render_mode,
+                r_output = rasterize(adjusted_cam, strategy_->get_model(), bg, 1.0f, false, false, render_mode,
                                      nullptr);
             }
 

--- a/src/training/trainer.hpp
+++ b/src/training/trainer.hpp
@@ -109,6 +109,9 @@ namespace gs::training {
             Error
         };
 
+        // Returns the background color to use at a given iteration
+        torch::Tensor& background_for_step(int iter);
+
         // Protected method for processing a single training step
         std::expected<StepResult, std::string> train_step(
             int iter,
@@ -153,6 +156,7 @@ namespace gs::training {
         param::TrainingParameters params_;
 
         torch::Tensor background_{};
+        torch::Tensor bg_mix_buffer_;
         std::unique_ptr<TrainingProgress> progress_;
         size_t train_dataset_size_ = 0;
 


### PR DESCRIPTION
This change introduces a new training parameter to enable a time-varying background color. Modulating the background helps prevent the model from overfitting to a static background color, forcing it to learn more robust geometry and opacity.

This feature is very light on performance, as it only involves a few tensor operations per training step, and it does not significantly increase memory usage or computation time.

The feature is disabled by default and it can be enabled with the --bg-modulation flag.