### PR TITLE
added filename extention and improved readability of # of splats

### DIFF
--- a/src/visualizer/gui/panels/scene_panel.cpp
+++ b/src/visualizer/gui/panels/scene_panel.cpp
@@ -333,7 +333,7 @@ namespace gs::gui {
 
                 // Show gaussian count
                 ImGui::SameLine();
-                ImGui::TextDisabled("(%zu)", node.gaussian_count);
+                ImGui::TextColored(ImVec4(0.2f, 0.2f, 0.2f, 1), "(%zu)", node.gaussian_count);
 
                 // Selection
                 if (ImGui::IsItemClicked() && !ImGui::IsItemToggledOpen()) {

--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -104,7 +104,7 @@ namespace gs {
             }
 
             // Add to scene
-            std::string name = path.stem().string();
+            std::string name = path.filename().string();
             size_t gaussian_count = (*splat_data)->size();
             LOG_DEBUG("Adding PLY '{}' to scene with {} gaussians", name, gaussian_count);
 


### PR DESCRIPTION
with the new .sog support, it would be useful to add the filename extention to the scene panel to make it easier to identify .ply vs .sog file formats.
this patch uses the full filename instead of the stem() of the file.
also improved the readability of the # of splats that were almost not visible.
<img width="442" height="597" alt="image" src="https://github.com/user-attachments/assets/52c60e64-f006-46a2-982a-c8a1aede5067" />
